### PR TITLE
fix typescript compilation errors

### DIFF
--- a/src/snapshot/index.ts
+++ b/src/snapshot/index.ts
@@ -8,7 +8,9 @@ import { EOL } from 'os';
 
 
 export async function getVSCodeTokens(registry: tm.Registry, scope: string, source: string): Promise<AnnotatedLine[]> {
-    return registry.loadGrammar(scope).then((grammar: tm.IGrammar) => {
+    return registry.loadGrammar(scope).then((grammar: tm.IGrammar|null) => {
+
+        if (!grammar) throw new Error(`Could not load scope ${scope}`);
 
         let ruleStack: tm.StackElement = <any>null;
 

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -157,8 +157,8 @@ glob(program.testcases, (err,files) => {
         console.log(chalk.red("ERROR") + " no test cases found")
         process.exit(-1)
     }
-    const testResults: Promise<number[]> = Promise.all(files.map(filename => {
-        let tc: any = undefined;
+    const testResults: Promise<number[]> = Promise.all(files.map((filename): Promise<number> => {
+        let tc: GrammarTestCase|undefined = undefined;
         try {
             tc = parseGrammarTestCase(fs.readFileSync(filename).toString())
         } catch(error) {

--- a/src/unit/index.ts
+++ b/src/unit/index.ts
@@ -11,7 +11,9 @@ export {parseGrammarTestCase, GrammarTestCase, TestFailure, missingScopes_}
 
 
 export async function runGrammarTestCase(registry: tm.Registry, testCase: GrammarTestCase): Promise<TestFailure[]> {
-    return registry.loadGrammar(testCase.metadata.scope).then((grammar: tm.IGrammar) => {
+    return registry.loadGrammar(testCase.metadata.scope).then((grammar: tm.IGrammar|null) => {
+
+        if (!grammar) throw new Error(`Could not load scope ${testCase.metadata.scope}`);
 
         const assertions = toMap((x) => x.sourceLineNumber, testCase.assertions)
 


### PR DESCRIPTION
Currently, a TypeScript 3.4.5 or 3.7.2 compilation with `tsc` fails
because of strict typecheck errors. This commit fixes those type errors
so the project now compiles.