### PR TITLE
Format sources with prettier & remove unused code

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "trailingComma": "none",
+  "singleQuote": true,
+  "printWidth": 80
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1811,6 +1811,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
+      "dev": true
+    },
     "process-on-spawn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
   },
   "scripts": {
     "build": "npx tsc",
-    "test": "mocha -r ts-node/register 'test/**/*.test.ts'",
-    "coverage": "npx nyc --reporter=html mocha -r ts-node/register 'test/**/*.test.ts'"
+    "coverage": "npx nyc --reporter=html mocha -r ts-node/register 'test/**/*.test.ts'",
+    "format": "prettier --config .prettierrc 'src/**/*.ts' 'test/**/*.ts' --write",
+    "lint": "tslint -c tslint.json 'src/**/*.ts'",
+    "test": "mocha -r ts-node/register 'test/**/*.test.ts'"
   },
   "bin": {
     "vscode-tmgrammar-test": "./dist/src/unit.js",
@@ -42,6 +44,7 @@
     "istanbul": "^0.4.5",
     "mocha": "^6.2.3",
     "nyc": "^15.0.1",
+    "prettier": "^2.1.2",
     "ts-node": "^8.10.2",
     "tslint": "^5.20.1",
     "typescript": "^3.8.3"

--- a/src/snapshot.ts
+++ b/src/snapshot.ts
@@ -1,318 +1,428 @@
 #!/usr/bin/env node
 
 import * as fs from 'fs';
-
 import * as tty from 'tty';
-
 import chalk from 'chalk';
 import program from 'commander';
-
 import glob from 'glob';
-
 import { createRegistry } from './unit/index';
-
-import { EOL } from 'os'
-
-import { getVSCodeTokens } from './snapshot/index'
-import { renderSnap, parseSnap } from './snapshot/parsing'
+import { EOL } from 'os';
+import { getVSCodeTokens } from './snapshot/index';
+import { renderSnap, parseSnap } from './snapshot/parsing';
 import { AnnotatedLine, IToken } from './snapshot/model';
-
-// import { inspect } from 'util';
 import * as diff from 'diff';
 
 let packageJson = require('../../package.json');
 
-function collectGrammarOpts(value:String, previous:String[]):String[] {
-    return previous.concat([value]);
+function collectGrammarOpts(value: String, previous: String[]): String[] {
+  return previous.concat([value]);
 }
 
 program
-    .version(packageJson.version)
-    .description("Run VSCode textmate grammar snapshot tests")
-    .option('-s, --scope <scope>', 'Language scope, e.g. source.dhall')
-    .option('-g, --grammar <grammar>', 'Path to a grammar file, either .json or .xml. This option can be specified multiple times if multiple grammar needed.', collectGrammarOpts, [])
-    .option('-t, --testcases <glob>', 'A glob pattern which specifies testcases to run, e.g. \"./tests/**/test*.dhall\". Quotes are important!')
-    .option("-u, --updateSnapshot", 'overwrite all snap files with new changes')
-    .option("--printNotModified", 'include not modified scopes in the output', false)
-    .option("--expandDiff", 'produce each diff on two lines prefixed with "++" and "--"', false)
-    .parse(process.argv);
+  .version(packageJson.version)
+  .description('Run VSCode textmate grammar snapshot tests')
+  .option('-s, --scope <scope>', 'Language scope, e.g. source.dhall')
+  .option(
+    '-g, --grammar <grammar>',
+    'Path to a grammar file, either .json or .xml. This option can be specified multiple times if multiple grammar needed.',
+    collectGrammarOpts,
+    []
+  )
+  .option(
+    '-t, --testcases <glob>',
+    'A glob pattern which specifies testcases to run, e.g. "./tests/**/test*.dhall". Quotes are important!'
+  )
+  .option('-u, --updateSnapshot', 'overwrite all snap files with new changes')
+  .option(
+    '--printNotModified',
+    'include not modified scopes in the output',
+    false
+  )
+  .option(
+    '--expandDiff',
+    'produce each diff on two lines prefixed with "++" and "--"',
+    false
+  )
+  .parse(process.argv);
 
-
-if (program.scope === undefined || program.grammar === undefined || program.grammar.length === 0 || program.testcases === undefined) {
-    program.help()
+if (
+  program.scope === undefined ||
+  program.grammar === undefined ||
+  program.grammar.length === 0 ||
+  program.testcases === undefined
+) {
+  program.help();
 }
 
-
-let isatty = tty.isatty(1) && tty.isatty(2)
+let isatty = tty.isatty(1) && tty.isatty(2);
 
 const symbols = {
-    ok: '✓',
-    err: '✖',
-    dot: '․',
-    comma: ',',
-    bang: '!'
+  ok: '✓',
+  err: '✖',
+  dot: '․',
+  comma: ',',
+  bang: '!'
 };
 
 if (process.platform === 'win32') {
-    symbols.ok = '\u221A';
-    symbols.err = '\u00D7';
-    symbols.dot = '.';
+  symbols.ok = '\u221A';
+  symbols.err = '\u00D7';
+  symbols.dot = '.';
 }
 
 let terminalWidth = 75;
 
 if (isatty) {
-    terminalWidth = (process.stdout as tty.WriteStream).getWindowSize()[0];
+  terminalWidth = (process.stdout as tty.WriteStream).getWindowSize()[0];
 }
 
-
-const TestFailed = -1
-const TestSuccessful = 0
-const Padding = "  "
-
+const TestFailed = -1;
+const TestSuccessful = 0;
+const Padding = '  ';
 
 const registry = createRegistry(program.grammar);
 
 glob(program.testcases, (err, files0) => {
-    if (err !== null) {
-        console.log(chalk.red("ERROR") + " glob pattern is incorrect: '" + chalk.gray(program.testcases) + "'")
-        console.log(err)
-        process.exit(-1)
-    }
-    const files = files0.filter(x => !x.endsWith(".snap"))
-    if (files.length === 0) {
-        console.log(chalk.red("ERROR") + " no test cases found")
-        process.exit(-1)
-    }
-    const testResults: Promise<number[]> = Promise.all(files.map(filename => {
-        const src = fs.readFileSync(filename).toString()
-        return getVSCodeTokens(registry, program.scope, src)
-            .then(tokens => {
-                if (fs.existsSync(filename + ".snap")) {
-                    if (program.updateSnapshot) {
-                        console.log(chalk.yellowBright("Updating snapshot for") + chalk.whiteBright(filename + ".snap"))
-                        fs.writeFileSync(filename + ".snap", renderSnap(tokens), 'utf8')
-                        return TestSuccessful;
-                    } else {
-                        const expectedTokens = parseSnap(fs.readFileSync(filename + ".snap").toString())
-                        return renderTestResult(filename, expectedTokens, tokens);
-                    }
-                } else {
-                    console.log(chalk.yellowBright("Generating snapshot ") + chalk.whiteBright(filename + ".snap"))
-                    fs.writeFileSync(filename + ".snap", renderSnap(tokens))
-                    return TestSuccessful;
-                }
-            })
-            .catch(error => {
-                console.log(chalk.red("ERROR") + " can't run testcase: " + chalk.whiteBright(filename))
-                console.log(error)
-                return TestFailed;
-            })
-    }));
-
-    testResults.then(xs => {
-        const result = xs.reduce((a, b) => a + b, 0)
-        if (result === TestSuccessful) {
-            process.exit(0);
-        } else {
-            process.exit(-1);
-        }
+  if (err !== null) {
+    console.log(
+      chalk.red('ERROR') +
+        " glob pattern is incorrect: '" +
+        chalk.gray(program.testcases) +
+        "'"
+    );
+    console.log(err);
+    process.exit(-1);
+  }
+  const files = files0.filter((x) => !x.endsWith('.snap'));
+  if (files.length === 0) {
+    console.log(chalk.red('ERROR') + ' no test cases found');
+    process.exit(-1);
+  }
+  const testResults: Promise<number[]> = Promise.all(
+    files.map((filename) => {
+      const src = fs.readFileSync(filename).toString();
+      return getVSCodeTokens(registry, program.scope, src)
+        .then((tokens) => {
+          if (fs.existsSync(filename + '.snap')) {
+            if (program.updateSnapshot) {
+              console.log(
+                chalk.yellowBright('Updating snapshot for') +
+                  chalk.whiteBright(filename + '.snap')
+              );
+              fs.writeFileSync(filename + '.snap', renderSnap(tokens), 'utf8');
+              return TestSuccessful;
+            } else {
+              const expectedTokens = parseSnap(
+                fs.readFileSync(filename + '.snap').toString()
+              );
+              return renderTestResult(filename, expectedTokens, tokens);
+            }
+          } else {
+            console.log(
+              chalk.yellowBright('Generating snapshot ') +
+                chalk.whiteBright(filename + '.snap')
+            );
+            fs.writeFileSync(filename + '.snap', renderSnap(tokens));
+            return TestSuccessful;
+          }
+        })
+        .catch((error) => {
+          console.log(
+            chalk.red('ERROR') +
+              " can't run testcase: " +
+              chalk.whiteBright(filename)
+          );
+          console.log(error);
+          return TestFailed;
+        });
     })
+  );
 
+  testResults.then((xs) => {
+    const result = xs.reduce((a, b) => a + b, 0);
+    if (result === TestSuccessful) {
+      process.exit(0);
+    } else {
+      process.exit(-1);
+    }
+  });
 });
 
-function renderTestResult(filename: string, expected: AnnotatedLine[], actual: AnnotatedLine[]): number {
+function renderTestResult(
+  filename: string,
+  expected: AnnotatedLine[],
+  actual: AnnotatedLine[]
+): number {
+  if (expected.length !== actual.length) {
+    console.log(
+      chalk.red('ERROR running testcase ') +
+        chalk.whiteBright(filename) +
+        chalk.red(
+          ` snapshot and actual file contain different number of lines.${EOL}`
+        )
+    );
+    return TestFailed;
+  }
 
-
-
-    if (expected.length !== actual.length) {
-        console.log(chalk.red("ERROR running testcase ") + chalk.whiteBright(filename) + chalk.red(` snapshot and actual file contain different number of lines.${EOL}`))
-        return TestFailed;
+  for (let i = 0; i < expected.length; i++) {
+    const exp = expected[i];
+    const act = actual[i];
+    if (exp.src !== act.src) {
+      console.log(
+        chalk.red('ERROR running testcase ') +
+          chalk.whiteBright(filename) +
+          chalk.red(
+            ` source different snapshot at line ${i + 1}.${EOL} expected: ${
+              exp.src
+            }${EOL} actual: ${act.src}${EOL}`
+          )
+      );
+      return TestFailed;
     }
+  }
 
-    for (let i = 0; i < expected.length; i++) {
-        const exp = expected[i];
-        const act = actual[i];
-        if (exp.src !== act.src) {
-            console.log(chalk.red("ERROR running testcase ") + chalk.whiteBright(filename) + chalk.red(` source different snapshot at line ${i + 1}.${EOL} expected: ${exp.src}${EOL} actual: ${act.src}${EOL}`))
-            return TestFailed;
-        }
-    }
+  // renderSnap won't produce assertions for empty lines, so we'll remove them here
+  // for both actual end expected
+  let actual1 = actual.filter((a) => a.src.trim().length > 0);
+  let expected1 = expected.filter((a) => a.src.trim().length > 0);
 
-    // renderSnap won't produce assertions for empty lines, so we'll remove them here
-    // for both actual end expected
-    let actual1 = actual.filter(a => a.src.trim().length > 0);
-    let expected1 = expected.filter(a => a.src.trim().length > 0);
+  const wrongLines = flatten(
+    expected1.map((exp, i) => {
+      const act = actual1[i];
 
-    const wrongLines = flatten(expected1.map((exp, i) => {
-        const act = actual1[i];
+      const expTokenMap = toMap(
+        (t) => `${t.startIndex}:${t.startIndex}`,
+        exp.tokens
+      );
+      const actTokenMap = toMap(
+        (t) => `${t.startIndex}:${t.startIndex}`,
+        act.tokens
+      );
 
-        const expTokenMap = toMap(t => `${t.startIndex}:${t.startIndex}`, exp.tokens)
-        const actTokenMap = toMap(t => `${t.startIndex}:${t.startIndex}`, act.tokens)
-
-
-
-
-        const removed = exp.tokens.filter(t => actTokenMap[`${t.startIndex}:${t.startIndex}`] === undefined).map(t => {
-            return <TChanges>{
-                changes: [<TChange>{
-                    text: t.scopes.join(" "),
-                    changeType: Removed
-                }],
-                from: t.startIndex,
-                to: t.endIndex,
-
-            }
+      const removed = exp.tokens
+        .filter(
+          (t) => actTokenMap[`${t.startIndex}:${t.startIndex}`] === undefined
+        )
+        .map((t) => {
+          return <TChanges>{
+            changes: [
+              <TChange>{
+                text: t.scopes.join(' '),
+                changeType: Removed
+              }
+            ],
+            from: t.startIndex,
+            to: t.endIndex
+          };
         });
-        const added = act.tokens.filter(t => expTokenMap[`${t.startIndex}:${t.startIndex}`] === undefined).map(t => {
-            return <TChanges>{
-                changes: [<TChange>{
-                    text: t.scopes.join(" "),
-                    changeType: Added
-                }],
-                from: t.startIndex,
-                to: t.endIndex
-            }
+      const added = act.tokens
+        .filter(
+          (t) => expTokenMap[`${t.startIndex}:${t.startIndex}`] === undefined
+        )
+        .map((t) => {
+          return <TChanges>{
+            changes: [
+              <TChange>{
+                text: t.scopes.join(' '),
+                changeType: Added
+              }
+            ],
+            from: t.startIndex,
+            to: t.endIndex
+          };
         });
 
-        const modified = flatten(act.tokens.map(a => {
-            const e = expTokenMap[`${a.startIndex}:${a.startIndex}`]
-            if (e !== undefined) {
-                const changes = diff.diffArrays(e.scopes, a.scopes)
-                if (changes.length === 1 && !changes[0].added && !changes[0].removed) {
-                    return []
-                }
-
-                const tchanges = changes.map(change => {
-                    let changeType = change.added ? Added : (change.removed ? Removed : NotModified);
-                    return <TChange>{
-                        text: change.value.join(" "),
-                        changeType: changeType
-                    };
-                });
-                return [<TChanges>{
-                    changes: tchanges,
-                    from: a.startIndex,
-                    to: a.endIndex
-                }]
-
-            } else {
-                return [];
+      const modified = flatten(
+        act.tokens.map((a) => {
+          const e = expTokenMap[`${a.startIndex}:${a.startIndex}`];
+          if (e !== undefined) {
+            const changes = diff.diffArrays(e.scopes, a.scopes);
+            if (
+              changes.length === 1 &&
+              !changes[0].added &&
+              !changes[0].removed
+            ) {
+              return [];
             }
-        }));
 
-        const allChanges = modified.concat(added).concat(removed).sort((x, y) => (x.from - y.from) * 10000 + (x.to - y.to))
-        if (allChanges.length > 0) {
-            return [[allChanges, exp.src, i] as [TChanges[], string, number]];
-        } else {
+            const tchanges = changes.map((change) => {
+              let changeType = change.added
+                ? Added
+                : change.removed
+                ? Removed
+                : NotModified;
+              return <TChange>{
+                text: change.value.join(' '),
+                changeType: changeType
+              };
+            });
+            return [
+              <TChanges>{
+                changes: tchanges,
+                from: a.startIndex,
+                to: a.endIndex
+              }
+            ];
+          } else {
             return [];
-        }
-    }));
+          }
+        })
+      );
 
-    if (wrongLines.length > 0) {
-        console.log(chalk.red("ERROR in test case ") + chalk.whiteBright(filename))
-        console.log(Padding + Padding + chalk.red("-- existing snapshot"))
-        console.log(Padding + Padding + chalk.green("++ new changes"))
-        console.log()
+      const allChanges = modified
+        .concat(added)
+        .concat(removed)
+        .sort((x, y) => (x.from - y.from) * 10000 + (x.to - y.to));
+      if (allChanges.length > 0) {
+        return [[allChanges, exp.src, i] as [TChanges[], string, number]];
+      } else {
+        return [];
+      }
+    })
+  );
 
-        if (program.expandDiff) {
-            printDiffOnTwoLines(wrongLines)
-        } else {
-            printDiffInline(wrongLines)
-        }
+  if (wrongLines.length > 0) {
+    console.log(chalk.red('ERROR in test case ') + chalk.whiteBright(filename));
+    console.log(Padding + Padding + chalk.red('-- existing snapshot'));
+    console.log(Padding + Padding + chalk.green('++ new changes'));
+    console.log();
 
-        console.log();
-        return TestFailed;
+    if (program.expandDiff) {
+      printDiffOnTwoLines(wrongLines);
     } else {
-        console.log(chalk.green(symbols.ok) + " " + chalk.whiteBright(filename) + " run successfully.")
-        return TestSuccessful;
+      printDiffInline(wrongLines);
     }
 
+    console.log();
+    return TestFailed;
+  } else {
+    console.log(
+      chalk.green(symbols.ok) +
+        ' ' +
+        chalk.whiteBright(filename) +
+        ' run successfully.'
+    );
+    return TestSuccessful;
+  }
 }
 
 function printDiffInline(wrongLines: [TChanges[], string, number][]) {
-    wrongLines.forEach(([changes, src, i]) => {
-        const lineNumberOffset = printSourceLine(src, i)
-        changes.forEach(tchanges => {
-            const change = tchanges.changes.filter(c => program.printNotModified || c.changeType !== NotModified).map(c => {
-                let color = c.changeType === Added ? chalk.green : (c.changeType === Removed ? chalk.red : chalk.gray);
-                return color(c.text);
-            }).join(" ")
-            printAccents(lineNumberOffset, tchanges.from, tchanges.to, change)
+  wrongLines.forEach(([changes, src, i]) => {
+    const lineNumberOffset = printSourceLine(src, i);
+    changes.forEach((tchanges) => {
+      const change = tchanges.changes
+        .filter((c) => program.printNotModified || c.changeType !== NotModified)
+        .map((c) => {
+          let color =
+            c.changeType === Added
+              ? chalk.green
+              : c.changeType === Removed
+              ? chalk.red
+              : chalk.gray;
+          return color(c.text);
         })
-        console.log();
+        .join(' ');
+      printAccents(lineNumberOffset, tchanges.from, tchanges.to, change);
     });
+    console.log();
+  });
 }
 
 function printDiffOnTwoLines(wrongLines: [TChanges[], string, number][]) {
-    wrongLines.forEach(([changes, src, i]) => {
-        const lineNumberOffset = printSourceLine(src, i)
-        changes.forEach(tchanges => {
-            const removed = tchanges.changes.filter(c => c.changeType === Removed || (c.changeType === NotModified && program.printNotModified)).map(c => {
-                return chalk.red(c.text);
-            }).join(" ")
-            const added = tchanges.changes.filter(c => c.changeType === Added || (c.changeType === NotModified && program.printNotModified)).map(c => {
-                return chalk.green(c.text);
-            }).join(" ")
-            printAccents1(lineNumberOffset, tchanges.from, tchanges.to, chalk.red("-- ") + removed, Removed)
-            printAccents1(lineNumberOffset, tchanges.from, tchanges.to, chalk.green("++ ") + added, Added)
+  wrongLines.forEach(([changes, src, i]) => {
+    const lineNumberOffset = printSourceLine(src, i);
+    changes.forEach((tchanges) => {
+      const removed = tchanges.changes
+        .filter(
+          (c) =>
+            c.changeType === Removed ||
+            (c.changeType === NotModified && program.printNotModified)
+        )
+        .map((c) => {
+          return chalk.red(c.text);
         })
-        console.log();
+        .join(' ');
+      const added = tchanges.changes
+        .filter(
+          (c) =>
+            c.changeType === Added ||
+            (c.changeType === NotModified && program.printNotModified)
+        )
+        .map((c) => {
+          return chalk.green(c.text);
+        })
+        .join(' ');
+      printAccents1(
+        lineNumberOffset,
+        tchanges.from,
+        tchanges.to,
+        chalk.red('-- ') + removed,
+        Removed
+      );
+      printAccents1(
+        lineNumberOffset,
+        tchanges.from,
+        tchanges.to,
+        chalk.green('++ ') + added,
+        Added
+      );
     });
+    console.log();
+  });
 }
 
 function toMap<T>(f: (x: T) => string, xs: T[]): { [key: string]: T } {
-    return xs.reduce((m: { [key: string]: T }, x: T) => {
-        m[f(x)] = x;
-        return m;
-    }, {});
-}
-
-function arraysEqual<T>(a: T[], b: T[]): boolean {
-    if (a === b) { return true };
-    if (a === null || b === null) { return false };
-    if (a.length !== b.length) { return false };
-
-    for (var i = 0; i < a.length; ++i) {
-        if (a[i] !== b[i]) { return false };
-    }
-    return true;
+  return xs.reduce((m: { [key: string]: T }, x: T) => {
+    m[f(x)] = x;
+    return m;
+  }, {});
 }
 
 function flatten<T>(arr: T[][]): T[] {
-    return arr.reduce((acc, val) => acc.concat(val), []);
+  return arr.reduce((acc, val) => acc.concat(val), []);
 }
 
 interface TChanges {
-    changes: TChange[]
-    from: number
-    to: number
+  changes: TChange[];
+  from: number;
+  to: number;
 }
 
 interface TChange {
-    text: string
-    changeType: number // 0 - not modified, 1 - removed, 2 - added
+  text: string;
+  changeType: number; // 0 - not modified, 1 - removed, 2 - added
 }
 
-const NotModified = 0
-const Removed = 1
-const Added = 2
+const NotModified = 0;
+const Removed = 1;
+const Added = 2;
 
 function printSourceLine(line: String, n: number): number {
-    const pos = (n + 1) + ": "
+  const pos = n + 1 + ': ';
 
-    console.log(Padding + chalk.gray(pos) + line)
-    return pos.length
+  console.log(Padding + chalk.gray(pos) + line);
+  return pos.length;
 }
 
 function printAccents(offset: number, from: number, to: number, diff: string) {
-    const accents = " ".repeat(from) + "^".repeat(to - from)
-    console.log(Padding + " ".repeat(offset) + accents + " " + diff)
+  const accents = ' '.repeat(from) + '^'.repeat(to - from);
+  console.log(Padding + ' '.repeat(offset) + accents + ' ' + diff);
 }
 
-function printAccents1(offset: number, from: number, to: number, diff: string, change: number) {
-    let color = change === Added ? chalk.green : (change === Removed ? chalk.red : chalk.gray);
-    let prefix = change === Added ? "++" : (change === Removed ? "--" : "  ");
-    const accents = color(" ".repeat(from) + "^".repeat(to - from))
-    console.log(color(prefix) + " ".repeat(offset) + accents + " " + diff)
+function printAccents1(
+  offset: number,
+  from: number,
+  to: number,
+  diff: string,
+  change: number
+) {
+  let color =
+    change === Added
+      ? chalk.green
+      : change === Removed
+      ? chalk.red
+      : chalk.gray;
+  let prefix = change === Added ? '++' : change === Removed ? '--' : '  ';
+  const accents = color(' '.repeat(from) + '^'.repeat(to - from));
+  console.log(color(prefix) + ' '.repeat(offset) + accents + ' ' + diff);
 }

--- a/src/snapshot/index.ts
+++ b/src/snapshot/index.ts
@@ -1,30 +1,29 @@
-
-
 import * as tm from 'vscode-textmate';
 import { AnnotatedLine } from './model';
 
+export async function getVSCodeTokens(
+  registry: tm.Registry,
+  scope: string,
+  source: string
+): Promise<AnnotatedLine[]> {
+  return registry.loadGrammar(scope).then((grammar: tm.IGrammar | null) => {
+    if (!grammar) {
+      throw new Error(`Could not load scope ${scope}`);
+    }
 
-export async function getVSCodeTokens(registry: tm.Registry, scope: string, source: string): Promise<AnnotatedLine[]> {
-    return registry.loadGrammar(scope).then((grammar: tm.IGrammar|null) => {
+    let ruleStack: tm.StackElement = <any>null;
 
-        if (!grammar) {
-            throw new Error(`Could not load scope ${scope}`);
-        }
+    return source.split(/\r\n|\n/).map((line: string, n: number) => {
+      var { tokens, ruleStack: ruleStack1 } = grammar.tokenizeLine(
+        line,
+        ruleStack
+      );
+      ruleStack = ruleStack1;
 
-        let ruleStack: tm.StackElement = <any>null;
-
-        return source.split(/\r\n|\n/).map((line: string, n: number) => {
-            var {tokens, ruleStack:ruleStack1} = grammar.tokenizeLine(line, ruleStack);
-            ruleStack = ruleStack1;
-
-            return <AnnotatedLine> {
-                src: line,
-                tokens:tokens
-            };
-        });
-
+      return <AnnotatedLine>{
+        src: line,
+        tokens: tokens
+      };
     });
-
+  });
 }
-
-

--- a/src/snapshot/model.ts
+++ b/src/snapshot/model.ts
@@ -1,9 +1,8 @@
-import {IToken} from 'vscode-textmate';
+import { IToken } from 'vscode-textmate';
 
-export {IToken};
+export { IToken };
 
 export interface AnnotatedLine {
-    src: string,
-    tokens: [IToken]
+  src: string;
+  tokens: [IToken];
 }
-

--- a/src/snapshot/parsing.ts
+++ b/src/snapshot/parsing.ts
@@ -1,50 +1,56 @@
+import { AnnotatedLine, IToken } from './model';
 
-import {AnnotatedLine, IToken} from "./model"
-
-
-export function parseSnap(s:string): AnnotatedLine[] {
-    let result: AnnotatedLine[] = []
-    let ls = s.split(/\r\n|\n/)
-    let i = 0
-    while(i < ls.length) {
-        let l = ls[i];
-        if (l.startsWith(">")) {
-            const src = l.substr(1);
-            i++;
-            let tokens: IToken[] = []
-            while(i < ls.length && ls[i].startsWith("#")) {
-                const startIndex = ls[i].indexOf("^")
-                const endIndex = ls[i].indexOf(" ", startIndex)
-                const scopes = ls[i].substr(endIndex + 1).split(/\s+/).filter(x => x !== "")
-                tokens.push(<IToken> {
-                    startIndex: startIndex - 1,
-                    endIndex: endIndex - 1,
-                    scopes: scopes
-                });
-                i++;
-            }
-            result.push(<AnnotatedLine> {
-                src: src,
-                tokens: tokens
-            });
-        } else {
-            i++;
-        }
+export function parseSnap(s: string): AnnotatedLine[] {
+  let result: AnnotatedLine[] = [];
+  let ls = s.split(/\r\n|\n/);
+  let i = 0;
+  while (i < ls.length) {
+    let l = ls[i];
+    if (l.startsWith('>')) {
+      const src = l.substr(1);
+      i++;
+      let tokens: IToken[] = [];
+      while (i < ls.length && ls[i].startsWith('#')) {
+        const startIndex = ls[i].indexOf('^');
+        const endIndex = ls[i].indexOf(' ', startIndex);
+        const scopes = ls[i]
+          .substr(endIndex + 1)
+          .split(/\s+/)
+          .filter((x) => x !== '');
+        tokens.push(<IToken>{
+          startIndex: startIndex - 1,
+          endIndex: endIndex - 1,
+          scopes: scopes
+        });
+        i++;
+      }
+      result.push(<AnnotatedLine>{
+        src: src,
+        tokens: tokens
+      });
+    } else {
+      i++;
     }
+  }
 
-    return result;
+  return result;
 }
 
-
 export function renderSnap(xs: AnnotatedLine[]): string {
-    let result : string[] = []
-    xs.forEach( line => {
-        result.push(">" + line.src)
-        if (line.src.trim().length > 0) {
-          line.tokens.forEach(token => {
-              result.push("#" + (" ".repeat(token.startIndex)) + ("^".repeat(token.endIndex - token.startIndex)) + " " + (token.scopes.join(" ")))
-          });
-        }
-    });
-    return result.join("\n")
+  let result: string[] = [];
+  xs.forEach((line) => {
+    result.push('>' + line.src);
+    if (line.src.trim().length > 0) {
+      line.tokens.forEach((token) => {
+        result.push(
+          '#' +
+            ' '.repeat(token.startIndex) +
+            '^'.repeat(token.endIndex - token.startIndex) +
+            ' ' +
+            token.scopes.join(' ')
+        );
+      });
+    }
+  });
+  return result.join('\n');
 }

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -1,197 +1,275 @@
 #!/usr/bin/env node
 
 import * as fs from 'fs';
-
 import * as tty from 'tty';
-
 import chalk from 'chalk';
 import program from 'commander';
-
 import glob from 'glob';
-
-import { EOL } from 'os'
-
-import { createRegistry, runGrammarTestCase, parseGrammarTestCase, GrammarTestCase, TestFailure } from './unit/index';
+import { EOL } from 'os';
+import {
+  createRegistry,
+  runGrammarTestCase,
+  parseGrammarTestCase,
+  GrammarTestCase,
+  TestFailure
+} from './unit/index';
 
 let packageJson = require('../../package.json');
 
-function collectGrammarOpts(value:String, previous:String[]):String[] {
-    return previous.concat([value]);
+function collectGrammarOpts(value: String, previous: String[]): String[] {
+  return previous.concat([value]);
 }
 
 // * don't forget the '' vscode-tmgrammar-test -s source.dhall -g testcase/dhall.tmLanguage.json -t '**/*.dhall'
 program
   .version(packageJson.version)
-  .description("Run Textmate grammar test cases using vscode-textmate")
+  .description('Run Textmate grammar test cases using vscode-textmate')
   .option('-s, --scope <scope>', 'Language scope, e.g. source.dhall')
-  .option('-g, --grammar <grammar>', 'Path to a grammar file, either .json or .xml. This option can be specified multiple times if multiple grammar needed.', collectGrammarOpts, [])
-  .option('-t, --testcases <glob>', 'A glob pattern which specifies testcases to run, e.g. \"./tests/**/test*.dhall\". Quotes are important!')
-  .option('-c, --compact', 'Display output in the compact format, which is easier to use with VSCode problem matchers')
+  .option(
+    '-g, --grammar <grammar>',
+    'Path to a grammar file, either .json or .xml. This option can be specified multiple times if multiple grammar needed.',
+    collectGrammarOpts,
+    []
+  )
+  .option(
+    '-t, --testcases <glob>',
+    'A glob pattern which specifies testcases to run, e.g. "./tests/**/test*.dhall". Quotes are important!'
+  )
+  .option(
+    '-c, --compact',
+    'Display output in the compact format, which is easier to use with VSCode problem matchers'
+  )
   .parse(process.argv);
 
-
-if (program.scope === undefined || program.grammar === undefined || program.grammar.length === 0 || program.testcases === undefined) {
-    program.help()
+if (
+  program.scope === undefined ||
+  program.grammar === undefined ||
+  program.grammar.length === 0 ||
+  program.testcases === undefined
+) {
+  program.help();
 }
 
-
-let isatty = tty.isatty(1) && tty.isatty(2)
+let isatty = tty.isatty(1) && tty.isatty(2);
 
 const symbols = {
-    ok: '✓',
-    err: '✖',
-    dot: '․',
-    comma: ',',
-    bang: '!'
-  };
+  ok: '✓',
+  err: '✖',
+  dot: '․',
+  comma: ',',
+  bang: '!'
+};
 
 if (process.platform === 'win32') {
-    symbols.ok = '\u221A';
-    symbols.err = '\u00D7';
-    symbols.dot = '.';
+  symbols.ok = '\u221A';
+  symbols.err = '\u00D7';
+  symbols.dot = '.';
 }
 
 let terminalWidth = 75;
 
 if (isatty) {
-    terminalWidth = (process.stdout as tty.WriteStream).getWindowSize()[0];
+  terminalWidth = (process.stdout as tty.WriteStream).getWindowSize()[0];
 }
 
+const TestFailed = -1;
+const TestSuccessful = 0;
+const Padding = '  ';
 
-const TestFailed = -1
-const TestSuccessful = 0
-const Padding = "  "
-
-
-const registry = createRegistry(program.grammar) ;
+const registry = createRegistry(program.grammar);
 
 function printSourceLine(testCase: GrammarTestCase, failure: TestFailure) {
-    const line = testCase.source[failure.srcLine]
-    const pos = (failure.line + 1) + ": "
-    const accents = " ".repeat(failure.start) + "^".repeat(failure.end - failure.start)
+  const line = testCase.source[failure.srcLine];
+  const pos = failure.line + 1 + ': ';
+  const accents =
+    ' '.repeat(failure.start) + '^'.repeat(failure.end - failure.start);
 
-    const termWidth = terminalWidth - pos.length - Padding.length - 5
+  const termWidth = terminalWidth - pos.length - Padding.length - 5;
 
-    const trimLeft = failure.end > termWidth ? Math.max(0, failure.start - 8) : 0
+  const trimLeft = failure.end > termWidth ? Math.max(0, failure.start - 8) : 0;
 
-    const line1 = line.substr(trimLeft)
-    const accents1 = accents.substr(trimLeft)
+  const line1 = line.substr(trimLeft);
+  const accents1 = accents.substr(trimLeft);
 
-    console.log(Padding + chalk.gray(pos) + line1.substr(0, termWidth))
-    console.log(Padding +  " ".repeat(pos.length) + accents1.substr(0, termWidth))
+  console.log(Padding + chalk.gray(pos) + line1.substr(0, termWidth));
+  console.log(Padding + ' '.repeat(pos.length) + accents1.substr(0, termWidth));
 }
 
 function printReason(testCase: GrammarTestCase, failure: TestFailure) {
-    if (failure.missing && failure.missing.length > 0) {
-        console.log(chalk.red(Padding + "missing required scopes: ") + chalk.gray(failure.missing.join(" ")))
-    }
-    if (failure.unexpected && failure.unexpected.length > 0) {
-        console.log(chalk.red(Padding + "prohibited scopes: ") + chalk.gray(failure.unexpected.join(" ")))
-    }
-    if (failure.actual !== undefined) {
-        console.log(chalk.red(Padding + "actual: ") + chalk.gray(failure.actual.join(" ")))
-    }
+  if (failure.missing && failure.missing.length > 0) {
+    console.log(
+      chalk.red(Padding + 'missing required scopes: ') +
+        chalk.gray(failure.missing.join(' '))
+    );
+  }
+  if (failure.unexpected && failure.unexpected.length > 0) {
+    console.log(
+      chalk.red(Padding + 'prohibited scopes: ') +
+        chalk.gray(failure.unexpected.join(' '))
+    );
+  }
+  if (failure.actual !== undefined) {
+    console.log(
+      chalk.red(Padding + 'actual: ') + chalk.gray(failure.actual.join(' '))
+    );
+  }
 }
 
-function displayTestResultFull(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): number {
-    if (failures.length === 0) {
-        console.log(chalk.green(symbols.ok) + " " + chalk.whiteBright(filename) + ` run successfuly.`)
-        return TestSuccessful;
-    } else {
-        console.log(chalk.red(symbols.err + " " + filename + " failed"))
-        failures.forEach(failure => {
-            const {l,s,e} = getCorrectedOffsets(failure)
-            console.log(Padding + "at [" + chalk.whiteBright(`${filename}:${l}:${s}:${e}`) + "]:")
-            printSourceLine(testCase, failure);
-            printReason(testCase, failure);
+function displayTestResultFull(
+  filename: string,
+  testCase: GrammarTestCase,
+  failures: TestFailure[]
+): number {
+  if (failures.length === 0) {
+    console.log(
+      chalk.green(symbols.ok) +
+        ' ' +
+        chalk.whiteBright(filename) +
+        ` run successfuly.`
+    );
+    return TestSuccessful;
+  } else {
+    console.log(chalk.red(symbols.err + ' ' + filename + ' failed'));
+    failures.forEach((failure) => {
+      const { l, s, e } = getCorrectedOffsets(failure);
+      console.log(
+        Padding +
+          'at [' +
+          chalk.whiteBright(`${filename}:${l}:${s}:${e}`) +
+          ']:'
+      );
+      printSourceLine(testCase, failure);
+      printReason(testCase, failure);
 
-            console.log(EOL)
-        });
-        console.log("");
-        return TestFailed;
-    }
-
-}
-
-function renderCompactErrorMsg(testCase: GrammarTestCase, failure: TestFailure): string {
-    let res = ""
-    if (failure.missing && failure.missing.length > 0) {
-        res += `Missing required scopes: [ ${failure.missing.join(" ")} ] `
-    }
-    if (failure.unexpected && failure.unexpected.length > 0) {
-        res += `Prohibited scopes: [ ${failure.unexpected.join(" ")} ] `
-    }
-    if (failure.actual !== undefined) {
-        res += `actual scopes: [${failure.actual.join(" ")}]`
-    }
-    return res;
-}
-
-function displayTestResultCompact(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): number {
-    if (failures.length === 0) {
-        console.log(chalk.green(symbols.ok) + " " + chalk.whiteBright(filename) + ` run successfuly.`)
-        return TestSuccessful;
-    } else {
-        failures.forEach(failure => {
-            console.log(`ERROR ${filename}:${failure.line + 1}:${failure.start + 1}:${failure.end+1} ${renderCompactErrorMsg(testCase, failure)}`)
-
-        });
-        return TestFailed;
-    }
-}
-
-function handleGrammarTestError(filename: string, testCase: GrammarTestCase, reason:any): number {
-    console.log(chalk.red(symbols.err) + " testcase " + chalk.gray(filename) + " aborted due to an error")
-    console.log(reason);
+      console.log(EOL);
+    });
+    console.log('');
     return TestFailed;
+  }
 }
 
-const displayTestResult = program.compact ? displayTestResultCompact : displayTestResultFull;
+function renderCompactErrorMsg(
+  testCase: GrammarTestCase,
+  failure: TestFailure
+): string {
+  let res = '';
+  if (failure.missing && failure.missing.length > 0) {
+    res += `Missing required scopes: [ ${failure.missing.join(' ')} ] `;
+  }
+  if (failure.unexpected && failure.unexpected.length > 0) {
+    res += `Prohibited scopes: [ ${failure.unexpected.join(' ')} ] `;
+  }
+  if (failure.actual !== undefined) {
+    res += `actual scopes: [${failure.actual.join(' ')}]`;
+  }
+  return res;
+}
 
-glob(program.testcases, (err,files) => {
-    if (err !== null) {
-        console.log(chalk.red("ERROR") + " glob pattern is incorrect: '" + chalk.gray(program.testcases) + "'")
-        console.log(err)
-        process.exit(-1)
-    }
-    if(files.length === 0) {
-        console.log(chalk.red("ERROR") + " no test cases found")
-        process.exit(-1)
-    }
-    const testResults: Promise<number[]> = Promise.all(files.map((filename): Promise<number> => {
-        let tc: GrammarTestCase|undefined = undefined;
+function displayTestResultCompact(
+  filename: string,
+  testCase: GrammarTestCase,
+  failures: TestFailure[]
+): number {
+  if (failures.length === 0) {
+    console.log(
+      chalk.green(symbols.ok) +
+        ' ' +
+        chalk.whiteBright(filename) +
+        ` run successfuly.`
+    );
+    return TestSuccessful;
+  } else {
+    failures.forEach((failure) => {
+      console.log(
+        `ERROR ${filename}:${failure.line + 1}:${failure.start + 1}:${
+          failure.end + 1
+        } ${renderCompactErrorMsg(testCase, failure)}`
+      );
+    });
+    return TestFailed;
+  }
+}
+
+function handleGrammarTestError(
+  filename: string,
+  testCase: GrammarTestCase,
+  reason: any
+): number {
+  console.log(
+    chalk.red(symbols.err) +
+      ' testcase ' +
+      chalk.gray(filename) +
+      ' aborted due to an error'
+  );
+  console.log(reason);
+  return TestFailed;
+}
+
+const displayTestResult = program.compact
+  ? displayTestResultCompact
+  : displayTestResultFull;
+
+glob(program.testcases, (err, files) => {
+  if (err !== null) {
+    console.log(
+      chalk.red('ERROR') +
+        " glob pattern is incorrect: '" +
+        chalk.gray(program.testcases) +
+        "'"
+    );
+    console.log(err);
+    process.exit(-1);
+  }
+  if (files.length === 0) {
+    console.log(chalk.red('ERROR') + ' no test cases found');
+    process.exit(-1);
+  }
+  const testResults: Promise<number[]> = Promise.all(
+    files.map(
+      (filename): Promise<number> => {
+        let tc: GrammarTestCase | undefined = undefined;
         try {
-            tc = parseGrammarTestCase(fs.readFileSync(filename).toString())
-        } catch(error) {
-            console.log(chalk.red("ERROR") + " can't parse testcase: " + chalk.whiteBright(filename) + "")
-            console.log(error)
-            return new Promise((resolve, reject) => { resolve(TestFailed); });
+          tc = parseGrammarTestCase(fs.readFileSync(filename).toString());
+        } catch (error) {
+          console.log(
+            chalk.red('ERROR') +
+              " can't parse testcase: " +
+              chalk.whiteBright(filename) +
+              ''
+          );
+          console.log(error);
+          return new Promise((resolve, reject) => {
+            resolve(TestFailed);
+          });
         }
         let testCase = tc as GrammarTestCase;
-        return runGrammarTestCase(registry, testCase).then( (failures) => {
-                    return displayTestResult(filename, testCase, failures)
-                }).catch((error: any) => {
-                    return handleGrammarTestError(filename, testCase, error);
-                })
+        return runGrammarTestCase(registry, testCase)
+          .then((failures) => {
+            return displayTestResult(filename, testCase, failures);
+          })
+          .catch((error: any) => {
+            return handleGrammarTestError(filename, testCase, error);
+          });
+      }
+    )
+  );
 
-    }));
-
-    testResults.then(xs => {
-        const result = xs.reduce( (a,b) => a + b, 0)
-        if (result === TestSuccessful) {
-            process.exit(0);
-        } else {
-            process.exit(-1);
-        }
-    })
-
+  testResults.then((xs) => {
+    const result = xs.reduce((a, b) => a + b, 0);
+    if (result === TestSuccessful) {
+      process.exit(0);
+    } else {
+      process.exit(-1);
+    }
+  });
 });
 
-
-function getCorrectedOffsets(failure: TestFailure): { l:number, s:number, e:number} {
-    return {
-        l: failure.line + 1,
-        s: failure.start + 1,
-        e: failure.end + 1
-    }
+function getCorrectedOffsets(
+  failure: TestFailure
+): { l: number; s: number; e: number } {
+  return {
+    l: failure.line + 1,
+    s: failure.start + 1,
+    e: failure.end + 1
+  };
 }

--- a/src/unit/index.ts
+++ b/src/unit/index.ts
@@ -1,139 +1,135 @@
-// import _ from "lodash";
 import * as fs from 'fs';
-//import { inspect } from 'util';
-
 import * as tm from 'vscode-textmate';
 import { GrammarTestCase, TestFailure } from './model';
 import { parseGrammarTestCase } from './parsing';
-//import { basename } from 'path';
 
-export { parseGrammarTestCase, GrammarTestCase, TestFailure, missingScopes_ }
+export { parseGrammarTestCase, GrammarTestCase, TestFailure, missingScopes_ };
 
+export async function runGrammarTestCase(
+  registry: tm.Registry,
+  testCase: GrammarTestCase
+): Promise<TestFailure[]> {
+  return registry
+    .loadGrammar(testCase.metadata.scope)
+    .then((grammar: tm.IGrammar | null) => {
+      if (!grammar) {
+        throw new Error(`Could not load scope ${testCase.metadata.scope}`);
+      }
 
-export async function runGrammarTestCase(registry: tm.Registry, testCase: GrammarTestCase): Promise<TestFailure[]> {
-    return registry.loadGrammar(testCase.metadata.scope).then((grammar: tm.IGrammar | null) => {
+      const assertions = toMap((x) => x.sourceLineNumber, testCase.assertions);
 
-        if (!grammar) {
-            throw new Error(`Could not load scope ${testCase.metadata.scope}`);
-        }
+      let ruleStack: tm.StackElement = <any>null;
 
-        const assertions = toMap((x) => x.sourceLineNumber, testCase.assertions)
+      let failures: TestFailure[] = [];
 
-        let ruleStack: tm.StackElement = <any>null;
+      testCase.source.forEach((line: string, n: number) => {
+        var { tokens, ruleStack: ruleStack1 } = grammar.tokenizeLine(
+          line,
+          ruleStack
+        );
+        ruleStack = ruleStack1;
 
-        let failures: TestFailure[] = []
+        if (assertions[n] !== undefined) {
+          let { testCaseLineNumber, scopeAssertions } = assertions[n];
 
-        testCase.source.forEach((line: string, n: number) => {
-            var { tokens, ruleStack: ruleStack1 } = grammar.tokenizeLine(line, ruleStack);
-            ruleStack = ruleStack1;
+          scopeAssertions.forEach(
+            ({ from, to, scopes: requiredScopes, exclude: excludedScopes }) => {
+              const xs = tokens.filter(
+                (t) => from < t.endIndex && to > t.startIndex
+              );
+              if (xs.length === 0 && requiredScopes.length > 0) {
+                failures.push(<TestFailure>{
+                  missing: requiredScopes,
+                  unexpected: [],
+                  actual: [],
+                  line: testCaseLineNumber,
+                  srcLine: n,
+                  start: from,
+                  end: to
+                });
+              } else {
+                xs.forEach((token) => {
+                  const unexpected = excludedScopes.filter((s) => {
+                    return token.scopes.includes(s);
+                  });
+                  const missing = missingScopes_(requiredScopes, token.scopes);
 
-            if (assertions[n] !== undefined) {
-                let { testCaseLineNumber, scopeAssertions } = assertions[n];
-
-                scopeAssertions.forEach(({ from, to, scopes: requiredScopes, exclude: excludedScopes }) => {
-                    const xs = tokens.filter((t) => from < t.endIndex && to > t.startIndex)
-                    if (xs.length === 0 && requiredScopes.length > 0) {
-                        failures.push(<TestFailure>{
-                            missing: requiredScopes,
-                            unexpected: [],
-                            actual: [],
-                            line: testCaseLineNumber,
-                            srcLine: n,
-                            start: from,
-                            end: to
-                        });
-                    } else {
-                        xs.forEach((token) => {
-                            const unexpected = excludedScopes.filter((s) => { return token.scopes.includes(s) })
-                            const missing = missingScopes_(requiredScopes, token.scopes)
-
-                            if (missing.length || unexpected.length) {
-                                failures.push(<TestFailure>{
-                                    missing: missing,
-                                    actual: token.scopes,
-                                    unexpected: unexpected,
-                                    line: testCaseLineNumber,
-                                    srcLine: n,
-                                    start: token.startIndex,
-                                    end: token.endIndex
-                                });
-                            }
-                        });
-                    }
-                })
+                  if (missing.length || unexpected.length) {
+                    failures.push(<TestFailure>{
+                      missing: missing,
+                      actual: token.scopes,
+                      unexpected: unexpected,
+                      line: testCaseLineNumber,
+                      srcLine: n,
+                      start: token.startIndex,
+                      end: token.endIndex
+                    });
+                  }
+                });
+              }
             }
-        });
-        return failures;
+          );
+        }
+      });
+      return failures;
     });
-
 }
 
-export function createRegistryFromGrammars(grammars: Array<{ path: string, content: string }>): tm.Registry {
-    let grammarIndex: { [key: string]: tm.IRawGrammar } = {}
+export function createRegistryFromGrammars(
+  grammars: Array<{ path: string; content: string }>
+): tm.Registry {
+  let grammarIndex: { [key: string]: tm.IRawGrammar } = {};
 
-    for (const grammar of grammars) {
-        const { path, content } = grammar;
-        let rawGrammar = tm.parseRawGrammar(content, path);
-        grammarIndex[rawGrammar.scopeName] = rawGrammar;
+  for (const grammar of grammars) {
+    const { path, content } = grammar;
+    let rawGrammar = tm.parseRawGrammar(content, path);
+    grammarIndex[rawGrammar.scopeName] = rawGrammar;
+  }
+
+  return new tm.Registry(<tm.RegistryOptions>{
+    loadGrammar: (scopeName) => {
+      if (grammarIndex[scopeName] !== undefined) {
+        return new Promise((fulfill, _) => {
+          fulfill(grammarIndex[scopeName]);
+        });
+      }
+      console.warn(`grammar not found for "${scopeName}"`);
+      return null;
     }
-
-    return new tm.Registry(<tm.RegistryOptions>{
-        loadGrammar: (scopeName) => {
-            if (grammarIndex[scopeName] !== undefined) {
-                return new Promise((fulfill, _) => {
-                    fulfill(grammarIndex[scopeName]);
-                });
-            }
-            console.warn(`grammar not found for "${scopeName}"`)
-            return null;
-        }
-    });
+  });
 }
 
 export function createRegistry(grammarPaths: string[]): tm.Registry {
-    return createRegistryFromGrammars(
-        grammarPaths.map((path) => {
-            return {
-                path,
-                content: fs.readFileSync(path).toString()
-            }
-        })
-    );
+  return createRegistryFromGrammars(
+    grammarPaths.map((path) => {
+      return {
+        path,
+        content: fs.readFileSync(path).toString()
+      };
+    })
+  );
 }
 
 // ------------------------------------------------------------ helper functions --------------------------------------
 
-
 function missingScopes_(rs: string[], as: string[]): string[] {
-    let i = 0, j = 0;
-    while (i < as.length && j < rs.length) {
-        if (as[i] === rs[j]) {
-            i++;
-            j++;
-        } else {
-            i++
-        }
+  let i = 0,
+    j = 0;
+  while (i < as.length && j < rs.length) {
+    if (as[i] === rs[j]) {
+      i++;
+      j++;
+    } else {
+      i++;
     }
+  }
 
-    return j === rs.length ? [] : rs.slice(j);
+  return j === rs.length ? [] : rs.slice(j);
 }
-
 
 function toMap<T>(f: (x: T) => number, xs: T[]): { [key: number]: T } {
-    return xs.reduce((m: { [key: number]: T }, x: T) => {
-        m[f(x)] = x;
-        return m;
-    }, {});
+  return xs.reduce((m: { [key: number]: T }, x: T) => {
+    m[f(x)] = x;
+    return m;
+  }, {});
 }
-
-function arraysEqual<T>(a: T[], b: T[]): boolean {
-    if (a === b) { return true };
-    if (a === null || b === null) { return false };
-    if (a.length !== b.length) { return false };
-
-    for (var i = 0; i < a.length; ++i) {
-        if (a[i] !== b[i]) { return false };
-    }
-    return true;
-}
-

--- a/src/unit/model.ts
+++ b/src/unit/model.ts
@@ -1,37 +1,35 @@
-
 export interface TestCaseMetadata {
-    commentToken: string
-    scope: string
-    description: string
-    allowMiddleLineAssertions: boolean
+  commentToken: string;
+  scope: string;
+  description: string;
+  allowMiddleLineAssertions: boolean;
 }
 
 export interface ScopeAssertion {
-    from: number // note the 0 index
-    to: number // exclusive
-    scopes: string[]
-    exclude: string[]
+  from: number; // note the 0 index
+  to: number; // exclusive
+  scopes: string[];
+  exclude: string[];
 }
 
 export interface LineAssertion {
-    testCaseLineNumber: number
-    sourceLineNumber: number
-    scopeAssertions: ScopeAssertion[]
+  testCaseLineNumber: number;
+  sourceLineNumber: number;
+  scopeAssertions: ScopeAssertion[];
 }
 
 export interface GrammarTestCase {
-    metadata: TestCaseMetadata
-    source: string[]
-    assertions: LineAssertion[]
+  metadata: TestCaseMetadata;
+  source: string[];
+  assertions: LineAssertion[];
 }
 
 export interface TestFailure {
-    missing: string[],
-    actual: string[],
-    unexpected: string[],
-    line: number,
-    srcLine: number,
-    start: number,
-    end: number
+  missing: string[];
+  actual: string[];
+  unexpected: string[];
+  line: number;
+  srcLine: number;
+  start: number;
+  end: number;
 }
-

--- a/src/unit/parsing.ts
+++ b/src/unit/parsing.ts
@@ -1,154 +1,168 @@
+import {
+  ScopeAssertion,
+  TestCaseMetadata,
+  LineAssertion,
+  GrammarTestCase
+} from './model';
+import { EOL } from 'os';
 
-import { ScopeAssertion, TestCaseMetadata, LineAssertion, GrammarTestCase } from './model';
-import { EOL } from 'os'
-// import { start } from 'repl';
+const leftArrowAssertRegex = /^(\s*)<([~]*)([-]+)((?:\s*\w[-\w.]*)*)(?:\s*-)?((?:\s*\w[-\w.]*)*)\s*$/;
+const upArrowAssertRegex = /^\s*((?:(?:\^+)\s*)+)((?:\s*\w[-\w.]*)*)(?:\s*-)?((?:\s*\w[-\w.]*)*)\s*$/;
 
-const leftArrowAssertRegex = /^(\s*)<([~]*)([-]+)((?:\s*\w[-\w.]*)*)(?:\s*-)?((?:\s*\w[-\w.]*)*)\s*$/
-const upArrowAssertRegex = /^\s*((?:(?:\^+)\s*)+)((?:\s*\w[-\w.]*)*)(?:\s*-)?((?:\s*\w[-\w.]*)*)\s*$/
+export function parseScopeAssertion(
+  testCaseLineNumber: number,
+  commentLength: number,
+  as: String
+): ScopeAssertion[] {
+  let s = as.slice(commentLength);
 
+  if (s.trim().startsWith('^')) {
+    let upArrowMatch = upArrowAssertRegex.exec(s);
+    if (upArrowMatch !== null) {
+      let [, , scopes = '', exclusions = ''] = upArrowMatch;
 
-export function parseScopeAssertion(testCaseLineNumber: number, commentLength: number, as: String): ScopeAssertion[] {
-    let s = as.slice(commentLength)
-
-    if (s.trim().startsWith('^')) {
-        let upArrowMatch = upArrowAssertRegex.exec(s)
-        if (upArrowMatch !== null) {
-            let [,, scopes = "", exclusions = ""] = upArrowMatch
-
-
-            if (scopes === "" && exclusions === "") {
-               throw new Error(`Inalid assertion at line ${testCaseLineNumber}:${EOL}${as}${EOL} Missing both required and prohibited scopes`)
-            } else {
-                const result = []
-                let startIdx =  s.indexOf("^")
-                while(startIdx !== -1) {
-                    let endIndx = startIdx
-                    while(s[endIndx + 1] === '^') { endIndx++ }
-                    result.push(<ScopeAssertion>{
-                        from: commentLength + startIdx,
-                        to: commentLength + endIndx + 1,
-                        scopes: scopes.split(/\s+/).filter((x) => x),
-                        exclude: exclusions.split(/\s+/).filter((x) => x)
-                    })
-                    startIdx =  s.indexOf("^", endIndx+1)
-                }
-                return result;
-            }
-        } else {
-            throw new Error(`Inalid assertion at line ${testCaseLineNumber}:${EOL}${as}${EOL}`)
+      if (scopes === '' && exclusions === '') {
+        throw new Error(
+          `Inalid assertion at line ${testCaseLineNumber}:${EOL}${as}${EOL} Missing both required and prohibited scopes`
+        );
+      } else {
+        const result = [];
+        let startIdx = s.indexOf('^');
+        while (startIdx !== -1) {
+          let endIndx = startIdx;
+          while (s[endIndx + 1] === '^') {
+            endIndx++;
+          }
+          result.push(<ScopeAssertion>{
+            from: commentLength + startIdx,
+            to: commentLength + endIndx + 1,
+            scopes: scopes.split(/\s+/).filter((x) => x),
+            exclude: exclusions.split(/\s+/).filter((x) => x)
+          });
+          startIdx = s.indexOf('^', endIndx + 1);
         }
+        return result;
+      }
+    } else {
+      throw new Error(
+        `Inalid assertion at line ${testCaseLineNumber}:${EOL}${as}${EOL}`
+      );
     }
+  }
 
-    let leftArrowMatch = leftArrowAssertRegex.exec(s)
+  let leftArrowMatch = leftArrowAssertRegex.exec(s);
 
-    if (leftArrowMatch !== null) {
-        let [, , tildas, dashes, scopes = "", exclusions = ""] = leftArrowMatch
-        if (scopes === "" && exclusions === "") {
-            throw new Error(`Inalid assertion at line ${testCaseLineNumber}:${EOL}${as}${EOL} Missing both required and prohibited scopes`)
-        } else {
-            return [{
-                from: tildas.length,
-                to: tildas.length + dashes.length,
-                scopes: scopes.split(/\s+/).filter((x) => x),
-                exclude: exclusions.split(/\s+/).filter((x) => x)
-            }]
+  if (leftArrowMatch !== null) {
+    let [, , tildas, dashes, scopes = '', exclusions = ''] = leftArrowMatch;
+    if (scopes === '' && exclusions === '') {
+      throw new Error(
+        `Inalid assertion at line ${testCaseLineNumber}:${EOL}${as}${EOL} Missing both required and prohibited scopes`
+      );
+    } else {
+      return [
+        {
+          from: tildas.length,
+          to: tildas.length + dashes.length,
+          scopes: scopes.split(/\s+/).filter((x) => x),
+          exclude: exclusions.split(/\s+/).filter((x) => x)
         }
+      ];
     }
+  }
 
-    return [];
-
+  return [];
 }
 
+let headerErrorMessage =
+  `Expecting the first line in the syntax test file to be in the following format:${EOL}` +
+  `<comment character(s)> SYNTAX TEST \"<language identifier>\"  (\"description\")?(+AllowMiddleLineAssertions)?${EOL}`;
 
+let headerRegex = /^([^\s]+)\s+SYNTAX\s+TEST\s+"([^"]+)"(?:\s+\"([^"]+)\")?\s*(\+AllowMiddleLineAssertions)?\s*$/;
 
-let headerErrorMessage = `Expecting the first line in the syntax test file to be in the following format:${EOL}` +
-    `<comment character(s)> SYNTAX TEST \"<language identifier>\"  (\"description\")?(+AllowMiddleLineAssertions)?${EOL}`
-
-let headerRegex = /^([^\s]+)\s+SYNTAX\s+TEST\s+"([^"]+)"(?:\s+\"([^"]+)\")?\s*(\+AllowMiddleLineAssertions)?\s*$/
-
-/*
-  parse the first line with the format:
-  <comment character(s)> SYNTAX TEST "<language identifier>" <"description">? ([+-]<flag>)*
-*/
-
+/**
+ * parse the first line with the format:
+ * <comment character(s)> SYNTAX TEST "<language identifier>" <"description">? ([+-]<flag>)*
+ */
 export function parseHeader(as: string[]): TestCaseMetadata {
-    if (as.length < 1) { throw new Error(headerErrorMessage); }
+  if (as.length < 1) {
+    throw new Error(headerErrorMessage);
+  }
 
-    let matchResult = headerRegex.exec(as[0])
+  let matchResult = headerRegex.exec(as[0]);
 
-    if (matchResult === null) {
-        throw new Error(headerErrorMessage);
-    } else {
-        let [, commentToken, scope, description = "", allowMiddleLineAssertions = ""] = matchResult;
-
-        return <TestCaseMetadata>{
-            commentToken: commentToken,
-            scope: scope,
-            description: description,
-            allowMiddleLineAssertions: allowMiddleLineAssertions !== ""
-        }
-    }
-
+  if (matchResult === null) {
+    throw new Error(headerErrorMessage);
+  } else {
+    let [
+      ,
+      commentToken,
+      scope,
+      description = '',
+      allowMiddleLineAssertions = ''
+    ] = matchResult;
+    return <TestCaseMetadata>{
+      commentToken: commentToken,
+      scope: scope,
+      description: description,
+      allowMiddleLineAssertions: allowMiddleLineAssertions !== ''
+    };
+  }
 }
 
 export function parseGrammarTestCase(str: string): GrammarTestCase {
-    let headerLength = 1;
-    let lines = str.split(/\r\n|\n/);
-    let metadata = parseHeader(lines)
-    let { commentToken, allowMiddleLineAssertions } = metadata
-    let rest = lines.slice(headerLength)
+  let headerLength = 1;
+  let lines = str.split(/\r\n|\n/);
+  let metadata = parseHeader(lines);
+  let { commentToken, allowMiddleLineAssertions } = metadata;
+  let rest = lines.slice(headerLength);
 
-    function emptyLineAssertion(tcLineNumber: number, srcLineNumber: number): LineAssertion {
-        return <LineAssertion>{
-            testCaseLineNumber: tcLineNumber,
-            sourceLineNumber: srcLineNumber,
-            scopeAssertions: []
-        }
+  function emptyLineAssertion(
+    tcLineNumber: number,
+    srcLineNumber: number
+  ): LineAssertion {
+    return <LineAssertion>{
+      testCaseLineNumber: tcLineNumber,
+      sourceLineNumber: srcLineNumber,
+      scopeAssertions: []
+    };
+  }
+
+  var sourceLineNumber = 0;
+  let lineAssertions = <Array<LineAssertion>>[];
+  var currentLineAssertion = emptyLineAssertion(headerLength, 0);
+  let source = <Array<string>>[];
+  rest.forEach((s: string, i: number) => {
+    let tcLineNumber = headerLength + i;
+
+    if (allowMiddleLineAssertions && s.trim().startsWith(commentToken)) {
+      const indent = s.indexOf(commentToken) + commentToken.length; // FIXME: a bit ugly here
+      let as = parseScopeAssertion(tcLineNumber, indent, s);
+      currentLineAssertion.scopeAssertions = [
+        ...currentLineAssertion.scopeAssertions,
+        ...as
+      ];
+    } else if (s.startsWith(commentToken)) {
+      let as = parseScopeAssertion(tcLineNumber, commentToken.length, s);
+      currentLineAssertion.scopeAssertions = [
+        ...currentLineAssertion.scopeAssertions,
+        ...as
+      ];
+    } else {
+      if (currentLineAssertion.scopeAssertions.length !== 0) {
+        lineAssertions.push(currentLineAssertion);
+      }
+      currentLineAssertion = emptyLineAssertion(tcLineNumber, sourceLineNumber);
+      source.push(s);
+      sourceLineNumber++;
     }
+  });
+  if (currentLineAssertion.scopeAssertions.length !== 0) {
+    lineAssertions.push(currentLineAssertion);
+  }
 
-
-    var sourceLineNumber = 0;
-    let lineAssertions = <Array<LineAssertion>>[];
-    var currentLineAssertion = emptyLineAssertion(headerLength, 0);
-    let source = <Array<string>>[]
-    rest.forEach((s: string, i: number) => {
-        let tcLineNumber = headerLength + i;
-        
-        if (allowMiddleLineAssertions && s.trim().startsWith(commentToken)) {
-            const indent = s.indexOf(commentToken) + commentToken.length // FIXME: a bit ugly here
-            let as = parseScopeAssertion(tcLineNumber, indent, s)
-            currentLineAssertion.scopeAssertions = [...currentLineAssertion.scopeAssertions, ...as]
-
-            // if (!skipComments) {
-            //     source.push(s)
-            //     sourceLineNumber++;
-            // }
-        } else if (s.startsWith(commentToken)) {
-            let as = parseScopeAssertion(tcLineNumber, commentToken.length, s)
-            currentLineAssertion.scopeAssertions = [...currentLineAssertion.scopeAssertions, ...as]
-
-            // if (!skipComments) {
-            //     source.push(s)
-            //     sourceLineNumber++;
-            // }
-        } else {
-            if (currentLineAssertion.scopeAssertions.length === 0) {
-                // ignore existing one
-            } else {
-                lineAssertions.push(currentLineAssertion)
-            }
-            currentLineAssertion = emptyLineAssertion(tcLineNumber, sourceLineNumber)
-            source.push(s)
-            sourceLineNumber++;
-        }
-    });
-    if (currentLineAssertion.scopeAssertions.length !== 0) {
-        lineAssertions.push(currentLineAssertion)
-    }
-
-    return <GrammarTestCase>{
-        metadata: metadata,
-        source: source,
-        assertions: lineAssertions
-    }
+  return <GrammarTestCase>{
+    metadata: metadata,
+    source: source,
+    assertions: lineAssertions
+  };
 }

--- a/test/functional/snaps.test.ts
+++ b/test/functional/snaps.test.ts
@@ -1,62 +1,90 @@
-import child_process from 'child_process'
-import { expect } from 'chai'
-import fs from 'fs'
-import util from 'util'
+import child_process from 'child_process';
+import { expect } from 'chai';
+import fs from 'fs';
+import util from 'util';
 
-const exec = util.promisify(child_process.exec)
+const exec = util.promisify(child_process.exec);
 
 // FIXME: assertions and done()
 describe('snap test', () => {
-  const root = process.cwd()
+  const root = process.cwd();
 
   it('should report OK for test without errors', () => {
-    return exec(`node ${root}/dist/src/snapshot.js \\
+    return exec(
+      `node ${root}/dist/src/snapshot.js \\
       --scope source.dhall \\
       --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/snap-ok-scenario/simple.dhall`, {
-      cwd: root
-    }).then(({stdout, stderr}) => {
-          expect(stdout).to.eq(`✓ ${root}/test/functional/resources/snap-ok-scenario/simple.dhall run successfully.\n`)
-          expect(stderr).to.eq('')
-    })
-  })
+      -t ${__dirname}/resources/snap-ok-scenario/simple.dhall`,
+      {
+        cwd: root
+      }
+    ).then(({ stdout, stderr }) => {
+      expect(stdout).to.eq(
+        `✓ ${root}/test/functional/resources/snap-ok-scenario/simple.dhall run successfully.\n`
+      );
+      expect(stderr).to.eq('');
+    });
+  });
 
   it('should report wrong or missing scopes', () => {
-    return exec(`node ${root}/dist/src/snapshot.js  \\
+    return exec(
+      `node ${root}/dist/src/snapshot.js  \\
       --scope source.dhall \\
       --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/snap-simple-failure/simple.dhall`, {
-      cwd: root
-    })
-    .then(() => {throw new Error('should have failed')})
-    .catch(({stdout, stderr}) => {
+      -t ${__dirname}/resources/snap-simple-failure/simple.dhall`,
+      {
+        cwd: root
+      }
+    )
+      .then(() => {
+        throw new Error('should have failed');
+      })
+      .catch(({ stdout, stderr }) => {
         // fs.writeFileSync('stderr.txt', stderr)
         //  fs.writeFileSync('stdout.txt', stdout)
-      expect(stdout).to.eq(
-        fs.readFileSync(`${__dirname}/resources/snap-simple-failure/stdout.txt`).toString().replace(/<root>/, root))
-    })
-  })
+        expect(stdout).to.eq(
+          fs
+            .readFileSync(
+              `${__dirname}/resources/snap-simple-failure/stdout.txt`
+            )
+            .toString()
+            .replace(/<root>/, root)
+        );
+      });
+  });
 
   it('should report update snapshot', async () => {
-    fs.copyFileSync(`${__dirname}/resources/snap-update-snapshot/ref.dhall.snap`,
-                    `${__dirname}/resources/snap-update-snapshot/simple.dhall.snap`)
-    await exec(`node ${root}/dist/src/snapshot.js  \\
+    fs.copyFileSync(
+      `${__dirname}/resources/snap-update-snapshot/ref.dhall.snap`,
+      `${__dirname}/resources/snap-update-snapshot/simple.dhall.snap`
+    );
+    await exec(
+      `node ${root}/dist/src/snapshot.js  \\
       --scope source.dhall \\
       --grammar ${root}/test/resources/dhall.tmLanguage.json \\
       -t ${__dirname}/resources/snap-update-snapshot/simple.dhall \\
-      --updateSnapshot`, {
-      cwd: root
-    })
+      --updateSnapshot`,
+      {
+        cwd: root
+      }
+    );
 
-    await exec(`node ${root}/dist/src/snapshot.js  \\
+    await exec(
+      `node ${root}/dist/src/snapshot.js  \\
       --scope source.dhall \\
       --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/snap-update-snapshot/simple.dhall`, {
-      cwd: root
-    }).then(({stdout, stderr}) => {
-      expect(stdout).to.eq(`✓ ${root}/test/functional/resources/snap-update-snapshot/simple.dhall run successfully.\n`)
-      expect(stderr).to.eq('')
-    })
-    fs.unlinkSync(`${__dirname}/resources/snap-update-snapshot/simple.dhall.snap`)
-  })
-})
+      -t ${__dirname}/resources/snap-update-snapshot/simple.dhall`,
+      {
+        cwd: root
+      }
+    ).then(({ stdout, stderr }) => {
+      expect(stdout).to.eq(
+        `✓ ${root}/test/functional/resources/snap-update-snapshot/simple.dhall run successfully.\n`
+      );
+      expect(stderr).to.eq('');
+    });
+    fs.unlinkSync(
+      `${__dirname}/resources/snap-update-snapshot/simple.dhall.snap`
+    );
+  });
+});

--- a/test/functional/unit-tests.test.ts
+++ b/test/functional/unit-tests.test.ts
@@ -1,47 +1,55 @@
-import child_process from 'child_process'
-import { expect } from 'chai'
-import fs from 'fs'
-import util from 'util'
+import child_process from 'child_process';
+import { expect } from 'chai';
+import fs from 'fs';
+import util from 'util';
 
-const exec = util.promisify(child_process.exec)
+const exec = util.promisify(child_process.exec);
 
 // FIXME: assertions and done()
 describe('unit test', () => {
-  const root = process.cwd()
+  const root = process.cwd();
 
   it('should report OK for test without errors', () => {
-    return exec(`node ${root}/dist/src/unit.js \\
+    return exec(
+      `node ${root}/dist/src/unit.js \\
       --scope source.dhall \\
       --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/unit-ok-scenario/success.dhall`, {
-      cwd: root
-    }).then(({stdout, stderr}) => {
-          expect(stdout).to.eq(`✓ ${root}/test/functional/resources/unit-ok-scenario/success.dhall run successfuly.\n`)
-          expect(stderr).to.eq('')
-    })
-  })
+      -t ${__dirname}/resources/unit-ok-scenario/success.dhall`,
+      {
+        cwd: root
+      }
+    ).then(({ stdout, stderr }) => {
+      expect(stdout).to.eq(
+        `✓ ${root}/test/functional/resources/unit-ok-scenario/success.dhall run successfuly.\n`
+      );
+      expect(stderr).to.eq('');
+    });
+  });
 
   it('should report Unexpected scopes', () => {
-    return exec(`node ${root}/dist/src/unit.js  \\
+    return exec(
+      `node ${root}/dist/src/unit.js  \\
       --scope source.dhall \\
       --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/unit-report-unexpected-scopes/unexpected.scopes.test.dhall`, {
-      cwd: root
-    })
-    .then(() => {throw new Error('should have failed')})
-    .catch(({stdout, stderr}) => {
-       // fs.writeFileSync('stderr.txt', stderr)
+      -t ${__dirname}/resources/unit-report-unexpected-scopes/unexpected.scopes.test.dhall`,
+      {
+        cwd: root
+      }
+    )
+      .then(() => {
+        throw new Error('should have failed');
+      })
+      .catch(({ stdout, stderr }) => {
+        // fs.writeFileSync('stderr.txt', stderr)
         // fs.writeFileSync('stdout.text', stdout)
-      expect(stdout).to.deep.equal
-        (fs.readFileSync(`${__dirname}/resources/unit-report-unexpected-scopes/stdout.txt`).toString().replace(/<root>/g, root))
-    })
-
-
-
-
-
-
-
-
-  })
-})
+        expect(stdout).to.deep.equal(
+          fs
+            .readFileSync(
+              `${__dirname}/resources/unit-report-unexpected-scopes/stdout.txt`
+            )
+            .toString()
+            .replace(/<root>/g, root)
+        );
+      });
+  });
+});

--- a/test/unit/unit.test.ts
+++ b/test/unit/unit.test.ts
@@ -1,502 +1,529 @@
 'use strict';
-import { expect } from 'chai'
-import * as fs from 'fs'
+import { expect } from 'chai';
+import * as fs from 'fs';
 
-import { parseGrammarTestCase, GrammarTestCase, TestFailure, runGrammarTestCase, createRegistry } from '../../src/unit/index'
+import {
+  parseGrammarTestCase,
+  runGrammarTestCase,
+  createRegistry
+} from '../../src/unit/index';
 
 var registry = createRegistry(['./test/resources/dhall.tmLanguage.json']);
 
 function loadFile(filename: string): string {
-    return fs.readFileSync(filename).toString();
+  return fs.readFileSync(filename).toString();
 }
 
-
 describe('Grammar test case', () => {
-    it('should report no errors on correct grammar test', () => {
-        return runGrammarTestCase(registry, parseGrammarTestCase(loadFile("./test/resources/successful.test.dhall"))).then(result => {
-            expect(result).to.eql([]);
-        });
+  it('should report no errors on correct grammar test', () => {
+    return runGrammarTestCase(
+      registry,
+      parseGrammarTestCase(loadFile('./test/resources/successful.test.dhall'))
+    ).then((result) => {
+      expect(result).to.eql([]);
     });
-    it('should report missing scopes', () => {
-        return runGrammarTestCase(registry, parseGrammarTestCase(loadFile("./test/resources/missing.scopes.test.dhall"))).then(result => {
-            expect(result).to.eql(
-                [{
-                    missing: ['m1', 'keyword.operator.record.begin.dhall', 'm2.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "keyword.operator.record.begin.dhall"
-                    ],
-                    unexpected: [],
-                    line: 11,
-                    srcLine: 9,
-                    start: 4,
-                    end: 5
-                },
-                {
-                    missing: ['m3.foo', "variable.object.property.dhall"],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "variable.object.property.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 6,
-                    end: 16
-                },
-                {
-                    missing: ['m4.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "punctuation.separator.dictionary.key-value.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 17,
-                    end: 18
-                },
-                {
-                    missing: ['m5.foo'],
-                    actual: [
-
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "string.quoted.double.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 19,
-                    end: 20
-                },
-                {
-                    missing: ['m5.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "string.quoted.double.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 20,
-                    end: 26
-                },
-                {
-                    missing: ['m5.foo'],
-                    actual: [
-
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "string.quoted.double.dhall",
-                        "constant.other.placeholder.dhall",
-                        "punctuation.section.curly.begin.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 26,
-                    end: 28
-                },
-                {
-                    missing: ['m5.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "string.quoted.double.dhall",
-                        "constant.other.placeholder.dhall",
-                        "meta.label.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 28,
-                    end: 32
-                },
-                {
-                    missing: ['m5.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "string.quoted.double.dhall",
-                        "constant.other.placeholder.dhall",
-                        "punctuation.section.curly.end.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 32,
-                    end: 33
-                },
-                {
-                    missing: ['m5.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "string.quoted.double.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 33,
-                    end: 44
-                },
-                {
-                    missing: ['m5.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "string.quoted.double.dhall"
-                    ],
-                    unexpected: [],
-                    line: 13,
-                    srcLine: 10,
-                    start: 44,
-                    end: 45
-                },
-                {
-                    missing: ['m6.foo'],
-                    actual: [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "keyword.operator.record.end.dhall"
-                    ],
-                    unexpected: [],
-                    line: 20,
-                    srcLine: 12,
-                    start: 0,
-                    end: 1
-                }]
-            );
-        });
+  });
+  it('should report missing scopes', () => {
+    return runGrammarTestCase(
+      registry,
+      parseGrammarTestCase(
+        loadFile('./test/resources/missing.scopes.test.dhall')
+      )
+    ).then((result) => {
+      expect(result).to.eql([
+        {
+          missing: ['m1', 'keyword.operator.record.begin.dhall', 'm2.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'keyword.operator.record.begin.dhall'
+          ],
+          unexpected: [],
+          line: 11,
+          srcLine: 9,
+          start: 4,
+          end: 5
+        },
+        {
+          missing: ['m3.foo', 'variable.object.property.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'variable.object.property.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 6,
+          end: 16
+        },
+        {
+          missing: ['m4.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'punctuation.separator.dictionary.key-value.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 17,
+          end: 18
+        },
+        {
+          missing: ['m5.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 19,
+          end: 20
+        },
+        {
+          missing: ['m5.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 20,
+          end: 26
+        },
+        {
+          missing: ['m5.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'punctuation.section.curly.begin.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 26,
+          end: 28
+        },
+        {
+          missing: ['m5.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'meta.label.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 28,
+          end: 32
+        },
+        {
+          missing: ['m5.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'punctuation.section.curly.end.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 32,
+          end: 33
+        },
+        {
+          missing: ['m5.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 33,
+          end: 44
+        },
+        {
+          missing: ['m5.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 44,
+          end: 45
+        },
+        {
+          missing: ['m6.foo'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'keyword.operator.record.end.dhall'
+          ],
+          unexpected: [],
+          line: 20,
+          srcLine: 12,
+          start: 0,
+          end: 1
+        }
+      ]);
     });
-    it('should report unexpected scopes', () => {
-        return runGrammarTestCase(registry, parseGrammarTestCase(loadFile("./test/resources/unexpected.scopes.test.dhall"))).then(result => {
-            expect(result).to.eql([{
-                missing: [],
-                actual: ["source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "keyword.operator.record.begin.dhall"],
-                unexpected: ['source.dhall'],
-                line: 11,
-                srcLine: 9,
-                start: 4,
-                end: 5
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "variable.object.property.dhall",
-                ],
-                unexpected: ['variable.object.property.dhall', 'source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 6,
-                end: 16
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                ],
-                unexpected: ['source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 19,
-                end: 20
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                ],
-                unexpected: ['source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 20,
-                end: 26
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                    "constant.other.placeholder.dhall",
-                    "punctuation.section.curly.begin.dhall",
-                ],
-                unexpected: ['source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 26,
-                end: 28
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                    "constant.other.placeholder.dhall",
-                    "meta.label.dhall",
-                ],
-                unexpected: ['source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 28,
-                end: 32
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                    "constant.other.placeholder.dhall",
-                    "punctuation.section.curly.end.dhall",
-                ],
-                unexpected: ['source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 32,
-                end: 33
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                ],
-                unexpected: ['source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 33,
-                end: 44
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                ],
-                unexpected: ['source.dhall'],
-                line: 13,
-                srcLine: 10,
-                start: 44,
-                end: 45
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                    "constant.other.placeholder.dhall",
-                    "meta.label.dhall",
-                ],
-                unexpected: ['meta.label.dhall'],
-                line: 17,
-                srcLine: 11,
-                start: 28,
-                end: 32
-            },
-            {
-                missing: [],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "keyword.operator.record.end.dhall",
-                ],
-                unexpected:
-                    ['meta.declaration.data.record.block.dhall',
-                        'keyword.operator.record.end.dhall'],
-                line: 20,
-                srcLine: 12,
-                start: 0,
-                end: 1
-            }]);
-        });
+  });
+  it('should report unexpected scopes', () => {
+    return runGrammarTestCase(
+      registry,
+      parseGrammarTestCase(
+        loadFile('./test/resources/unexpected.scopes.test.dhall')
+      )
+    ).then((result) => {
+      expect(result).to.eql([
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'keyword.operator.record.begin.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 11,
+          srcLine: 9,
+          start: 4,
+          end: 5
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'variable.object.property.dhall'
+          ],
+          unexpected: ['variable.object.property.dhall', 'source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 6,
+          end: 16
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 19,
+          end: 20
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 20,
+          end: 26
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'punctuation.section.curly.begin.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 26,
+          end: 28
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'meta.label.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 28,
+          end: 32
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'punctuation.section.curly.end.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 32,
+          end: 33
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 33,
+          end: 44
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: ['source.dhall'],
+          line: 13,
+          srcLine: 10,
+          start: 44,
+          end: 45
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'meta.label.dhall'
+          ],
+          unexpected: ['meta.label.dhall'],
+          line: 17,
+          srcLine: 11,
+          start: 28,
+          end: 32
+        },
+        {
+          missing: [],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'keyword.operator.record.end.dhall'
+          ],
+          unexpected: [
+            'meta.declaration.data.record.block.dhall',
+            'keyword.operator.record.end.dhall'
+          ],
+          line: 20,
+          srcLine: 12,
+          start: 0,
+          end: 1
+        }
+      ]);
     });
-    it('should report out of place scopes', () => {
-        return runGrammarTestCase(registry, parseGrammarTestCase(loadFile("./test/resources/misplaced.scopes.test.dhall"))).then(result => {
-            expect(result).to.eql([{
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "punctuation.separator.dictionary.key-value.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 17,
-                end: 18
-            },
-            {
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 19,
-                end: 20
-            },
-            {
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 20,
-                end: 26
-            },
-            {
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                    "constant.other.placeholder.dhall",
-                    "punctuation.section.curly.begin.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 26,
-                end: 28
-            },
-            {
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                    "constant.other.placeholder.dhall",
-                    "meta.label.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 28,
-                end: 32
-            },
-            {
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall",
-                    "constant.other.placeholder.dhall",
-                    "punctuation.section.curly.end.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 32,
-                end: 33
-            },
-            {
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 33,
-                end: 44
-            },
-            {
-                missing: ["source.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "meta.declaration.data.record.literal.dhall",
-                    "string.quoted.double.dhall"
-                ],
-                unexpected: [],
-                line: 13,
-                srcLine: 10,
-                start: 44,
-                end: 45
-            },
-            {
-                missing: ["meta.declaration.data.record.block.dhall"],
-                actual: [
-                    "source.dhall",
-                    "meta.declaration.data.record.block.dhall",
-                    "keyword.operator.record.end.dhall"
-                ],
-                unexpected: [],
-                line: 20,
-                srcLine: 12,
-                start: 0,
-                end: 1
-            }]);
-        });
+  });
+  it('should report out of place scopes', () => {
+    return runGrammarTestCase(
+      registry,
+      parseGrammarTestCase(
+        loadFile('./test/resources/misplaced.scopes.test.dhall')
+      )
+    ).then((result) => {
+      expect(result).to.eql([
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'punctuation.separator.dictionary.key-value.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 17,
+          end: 18
+        },
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 19,
+          end: 20
+        },
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 20,
+          end: 26
+        },
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'punctuation.section.curly.begin.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 26,
+          end: 28
+        },
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'meta.label.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 28,
+          end: 32
+        },
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall',
+            'constant.other.placeholder.dhall',
+            'punctuation.section.curly.end.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 32,
+          end: 33
+        },
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 33,
+          end: 44
+        },
+        {
+          missing: ['source.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'string.quoted.double.dhall'
+          ],
+          unexpected: [],
+          line: 13,
+          srcLine: 10,
+          start: 44,
+          end: 45
+        },
+        {
+          missing: ['meta.declaration.data.record.block.dhall'],
+          actual: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'keyword.operator.record.end.dhall'
+          ],
+          unexpected: [],
+          line: 20,
+          srcLine: 12,
+          start: 0,
+          end: 1
+        }
+      ]);
     });
-    it('should report error when line assertion referes to non existing token', () => {
-        return runGrammarTestCase(registry, parseGrammarTestCase(loadFile("./test/resources/out.of.bounds.test.dhall"))).then(result => {
-            expect(result).to.eql(
-                [
-                    {
-                        "end": 32,
-                        "line": 5,
-                        "actual": [],
-                        "missing": [
-                            "missing.scope"
-                        ],
-                        "srcLine": 3,
-                        "start": 30,
-                        "unexpected": []
-                    }
-                ]
-            );
-        });
+  });
+  it('should report error when line assertion referes to non existing token', () => {
+    return runGrammarTestCase(
+      registry,
+      parseGrammarTestCase(
+        loadFile('./test/resources/out.of.bounds.test.dhall')
+      )
+    ).then((result) => {
+      expect(result).to.eql([
+        {
+          end: 32,
+          line: 5,
+          actual: [],
+          missing: ['missing.scope'],
+          srcLine: 3,
+          start: 30,
+          unexpected: []
+        }
+      ]);
     });
+  });
 });

--- a/test/unit/unit/parsing.test.ts
+++ b/test/unit/unit/parsing.test.ts
@@ -1,322 +1,330 @@
 'use strict';
-import { expect } from 'chai'
-import * as fs from 'fs'
+import { expect } from 'chai';
+import * as fs from 'fs';
 
-
-import { parseHeader, parseScopeAssertion, parseGrammarTestCase } from '../../../src/unit/parsing';
+import {
+  parseHeader,
+  parseScopeAssertion,
+  parseGrammarTestCase
+} from '../../../src/unit/parsing';
 
 describe('parseHeader', () => {
-    it('should parse one character comment token', () => {
-        var result = parseHeader(['# SYNTAX TEST "scala"'
-            , '#']);
-        expect(result).to.eql({
-            commentToken: "#",
-            description: "",
-            scope: "scala",
-            allowMiddleLineAssertions: false
-        });
+  it('should parse one character comment token', () => {
+    var result = parseHeader(['# SYNTAX TEST "scala"', '#']);
+    expect(result).to.eql({
+      commentToken: '#',
+      description: '',
+      scope: 'scala',
+      allowMiddleLineAssertions: false
     });
+  });
 
-    it('should parse +AllowMiddleLineAssertions flag', () => {
-        var result = parseHeader(['# SYNTAX TEST "scala" +AllowMiddleLineAssertions'
-            , '#']);
-        expect(result).to.eql({
-            commentToken: "#",
-            description: "",
-            scope: "scala",
-            allowMiddleLineAssertions: true
-        });
+  it('should parse +AllowMiddleLineAssertions flag', () => {
+    var result = parseHeader([
+      '# SYNTAX TEST "scala" +AllowMiddleLineAssertions',
+      '#'
+    ]);
+    expect(result).to.eql({
+      commentToken: '#',
+      description: '',
+      scope: 'scala',
+      allowMiddleLineAssertions: true
     });
+  });
 
-    it('should parse description', () => {
-        var result = parseHeader(['-- SYNTAX TEST "sql" "some description"']);
-        expect(result).to.eql({
-            commentToken: "--",
-            description: "some description",
-            scope: "sql",
-            allowMiddleLineAssertions: false
-
-        });
+  it('should parse description', () => {
+    var result = parseHeader(['-- SYNTAX TEST "sql" "some description"']);
+    expect(result).to.eql({
+      commentToken: '--',
+      description: 'some description',
+      scope: 'sql',
+      allowMiddleLineAssertions: false
     });
-    it('should throw meaningful error msg', () => {
-        expect(parseHeader.bind({}, ['-- SYNTAX TEST sql"']))
-            .to.throw("Expecting the first line in the syntax test file to be in the following format:\n" +
-                "<comment character(s)> SYNTAX TEST \"<language identifier>\"  (\"description\")?");
-
-    });
+  });
+  it('should throw meaningful error msg', () => {
+    expect(parseHeader.bind({}, ['-- SYNTAX TEST sql"'])).to.throw(
+      'Expecting the first line in the syntax test file to be in the following format:\n' +
+        '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?'
+    );
+  });
 });
 
 describe('parseScopeAssertion', () => {
-    it('should parse single ^ accent', () => {
-        expect(parseScopeAssertion(0, 1, "#^ source.dhall")).to.eql(
-            [{
-                "from": 1,
-                "scopes": [
-                    "source.dhall"
-                ],
-                exclude: [],
-                "to": 2
-            }]
-        )
-    });
-    it('should parse multiple ^^^^ accents', () => {
-        expect(parseScopeAssertion(0, 1, "#  ^^^^^^ source.dhall")).to.eql(
-            [{
-                "from": 3,
-                "scopes": [
-                    "source.dhall"
-                ],
-                exclude: [],
-                "to": 9
-            }]
-        )
-    });
+  it('should parse single ^ accent', () => {
+    expect(parseScopeAssertion(0, 1, '#^ source.dhall')).to.eql([
+      {
+        from: 1,
+        scopes: ['source.dhall'],
+        exclude: [],
+        to: 2
+      }
+    ]);
+  });
+  it('should parse multiple ^^^^ accents', () => {
+    expect(parseScopeAssertion(0, 1, '#  ^^^^^^ source.dhall')).to.eql([
+      {
+        from: 3,
+        scopes: ['source.dhall'],
+        exclude: [],
+        to: 9
+      }
+    ]);
+  });
 
-    it('should parse multiple scopes', () => {
-        expect(parseScopeAssertion(0, 1, "# ^^ source.dhall variable.other.dhall")).to.eql(
-            [{
-                "from": 2,
-                "scopes": [
-                    "source.dhall", "variable.other.dhall"
-                ],
-                exclude: [],
-                "to": 4
-            }]
-        )
-    });
+  it('should parse multiple scopes', () => {
+    expect(
+      parseScopeAssertion(0, 1, '# ^^ source.dhall variable.other.dhall')
+    ).to.eql([
+      {
+        from: 2,
+        scopes: ['source.dhall', 'variable.other.dhall'],
+        exclude: [],
+        to: 4
+      }
+    ]);
+  });
 
-    it('should parse multiple accent groups', () => {
-        expect(parseScopeAssertion(0, 1, "# ^^ ^^^ source.dhall")).to.deep.equal([
-              {
-                "exclude": [],
-                "from": 2,
-                "scopes": [
-                  "source.dhall"
-             ],
-                "to": 4
-              },
-              {
-                "exclude": [],
-                "from": 5,
-                "scopes": [
-                  "source.dhall"
-                ],
-                "to": 8
-              }
-            ])
-    });
+  it('should parse multiple accent groups', () => {
+    expect(parseScopeAssertion(0, 1, '# ^^ ^^^ source.dhall')).to.deep.equal([
+      {
+        exclude: [],
+        from: 2,
+        scopes: ['source.dhall'],
+        to: 4
+      },
+      {
+        exclude: [],
+        from: 5,
+        scopes: ['source.dhall'],
+        to: 8
+      }
+    ]);
+  });
 
-    it('should parse single <- left arrow', () => {
-        expect(parseScopeAssertion(0, 1, "# <- source.dhall")).to.eql(
-            [{
-                "from": 0,
-                "scopes": [
-                    "source.dhall"
-                ],
-                exclude: [],
-                "to": 1
-            }]
-        )
-    });
+  it('should parse single <- left arrow', () => {
+    expect(parseScopeAssertion(0, 1, '# <- source.dhall')).to.eql([
+      {
+        from: 0,
+        scopes: ['source.dhall'],
+        exclude: [],
+        to: 1
+      }
+    ]);
+  });
 
-    it('should parse multi <~~--- left arrow with padding', () => {
-        expect(parseScopeAssertion(0, 1, "# <~~~--- source.dhall")).to.eql(
-            [{
-                "from": 3,
-                "scopes": [
-                    "source.dhall"
-                ],
-                exclude: [],
-                "to": 6
-            }]
-        )
-    });
-    it('should parse single ^ accent with exclusion', () => {
-        expect(parseScopeAssertion(0, 1, "#^ - source.dhall")).to.eql(
-            [{
-                "from": 1,
-                "scopes": [],
-                exclude: ["source.dhall"],
-                "to": 2
-            }]
-        )
-    });
-    it('should parse  ^^^ accents with scopes and exclusion', () => {
-        expect(parseScopeAssertion(0, 1, "#^^^ foo.bar bar - source.dhall foo")).to.eql(
-            [{
-                "from": 1,
-                "scopes": ["foo.bar", "bar"],
-                exclude: ["source.dhall", "foo"],
-                "to": 4
-            }]
-        )
-    });
-    it('should parse <- with exclusion', () => {
-        expect(parseScopeAssertion(0, 1, "#<- - source.dhall")).to.eql(
-            [{
-                "from": 0,
-                "scopes": [],
-                exclude: ["source.dhall"],
-                "to": 1
-            }]
-        )
-    });
-    it('should parse  <- with scopes and exclusion', () => {
-        expect(parseScopeAssertion(0, 1, "#<-- foo.bar bar - source.dhall foo")).to.eql(
-            [{
-                "from": 0,
-                "scopes": ["foo.bar", "bar"],
-                exclude: ["source.dhall", "foo"],
-                "to": 2
-            }]
-        )
-    });
-    it('should parse correctly treat spaces at the end with ^^', () => {
-        expect(parseScopeAssertion(0, 1, "#^^ foo - bar   ")).to.eql(
-            [{
-                "from": 1,
-                "scopes": ["foo"],
-                exclude: ["bar"],
-                "to": 3
-            }]
-        )
-    });
-    it('should parse correctly treat spaces at the end with  <- ', () => {
-        expect(parseScopeAssertion(0, 1, "#<-- foo ")).to.eql(
-            [{
-                "from": 0,
-                "scopes": ["foo"],
-                exclude: [],
-                "to": 2
-            }]
-        )
-    });
-    it('should throw an error for an empty <- ', () => {
-        expect(() => parseScopeAssertion(0, 1, "#<-- - "))
-          .to
-          .throw('Inalid assertion at line 0:\n'
-               + '#<-- - \n'
-               + ' Missing both required and prohibited scopes')
-    });
-    it('should throw an error on empty ^ ', () => {
-        expect(() => parseScopeAssertion(0, 1, "# ^^^ "))
-        .to
-        .throw('Inalid assertion at line 0:\n'
-             + '# ^^^ \n'
-             + ' Missing both required and prohibited scopes')
-    });
+  it('should parse multi <~~--- left arrow with padding', () => {
+    expect(parseScopeAssertion(0, 1, '# <~~~--- source.dhall')).to.eql([
+      {
+        from: 3,
+        scopes: ['source.dhall'],
+        exclude: [],
+        to: 6
+      }
+    ]);
+  });
+  it('should parse single ^ accent with exclusion', () => {
+    expect(parseScopeAssertion(0, 1, '#^ - source.dhall')).to.eql([
+      {
+        from: 1,
+        scopes: [],
+        exclude: ['source.dhall'],
+        to: 2
+      }
+    ]);
+  });
+  it('should parse  ^^^ accents with scopes and exclusion', () => {
+    expect(
+      parseScopeAssertion(0, 1, '#^^^ foo.bar bar - source.dhall foo')
+    ).to.eql([
+      {
+        from: 1,
+        scopes: ['foo.bar', 'bar'],
+        exclude: ['source.dhall', 'foo'],
+        to: 4
+      }
+    ]);
+  });
+  it('should parse <- with exclusion', () => {
+    expect(parseScopeAssertion(0, 1, '#<- - source.dhall')).to.eql([
+      {
+        from: 0,
+        scopes: [],
+        exclude: ['source.dhall'],
+        to: 1
+      }
+    ]);
+  });
+  it('should parse  <- with scopes and exclusion', () => {
+    expect(
+      parseScopeAssertion(0, 1, '#<-- foo.bar bar - source.dhall foo')
+    ).to.eql([
+      {
+        from: 0,
+        scopes: ['foo.bar', 'bar'],
+        exclude: ['source.dhall', 'foo'],
+        to: 2
+      }
+    ]);
+  });
+  it('should parse correctly treat spaces at the end with ^^', () => {
+    expect(parseScopeAssertion(0, 1, '#^^ foo - bar   ')).to.eql([
+      {
+        from: 1,
+        scopes: ['foo'],
+        exclude: ['bar'],
+        to: 3
+      }
+    ]);
+  });
+  it('should parse correctly treat spaces at the end with  <- ', () => {
+    expect(parseScopeAssertion(0, 1, '#<-- foo ')).to.eql([
+      {
+        from: 0,
+        scopes: ['foo'],
+        exclude: [],
+        to: 2
+      }
+    ]);
+  });
+  it('should throw an error for an empty <- ', () => {
+    expect(() => parseScopeAssertion(0, 1, '#<-- - ')).to.throw(
+      'Inalid assertion at line 0:\n' +
+        '#<-- - \n' +
+        ' Missing both required and prohibited scopes'
+    );
+  });
+  it('should throw an error on empty ^ ', () => {
+    expect(() => parseScopeAssertion(0, 1, '# ^^^ ')).to.throw(
+      'Inalid assertion at line 0:\n' +
+        '# ^^^ \n' +
+        ' Missing both required and prohibited scopes'
+    );
+  });
 });
 
 describe('parseGrammarTestCase', () => {
-    it('should parse a valid test case', () => {
-        let testFile = fs.readFileSync('./test/resources/parser.test.dhall').toString()
-        expect(parseGrammarTestCase(testFile)).to.eql(parserTestDhallExpectedResult)
-    });
+  it('should parse a valid test case', () => {
+    let testFile = fs
+      .readFileSync('./test/resources/parser.test.dhall')
+      .toString();
+    expect(parseGrammarTestCase(testFile)).to.eql(
+      parserTestDhallExpectedResult
+    );
+  });
 
-    it('should parse a test case with a windows line endings', () => {
-        let originalFile = fs.readFileSync('./test/resources/parser.test.dhall').toString()
-        let crlfFile = originalFile.split("\n").join("\r\n")
-        expect(parseGrammarTestCase(crlfFile)).to.eql(parserTestDhallExpectedResult)
-    });
+  it('should parse a test case with a windows line endings', () => {
+    let originalFile = fs
+      .readFileSync('./test/resources/parser.test.dhall')
+      .toString();
+    let crlfFile = originalFile.split('\n').join('\r\n');
+    expect(parseGrammarTestCase(crlfFile)).to.eql(
+      parserTestDhallExpectedResult
+    );
+  });
 });
 
-
-
 const parserTestDhallExpectedResult = {
-    metadata:
+  metadata: {
+    commentToken: '--',
+    description: '',
+    scope: 'source.dhall',
+    allowMiddleLineAssertions: false
+  },
+  source: [
+    '',
+    '',
+    "{- Don't repeat yourself!",
+    '',
+    '   Repetition is error-prone',
+    '-}',
+    '',
+    '',
+    'let user = "bill"',
+    'in  { home       = "/home/${user}"',
+    '    , privateKey = "/home/${user}/id_ed25519"',
+    '    , publicKey  = "/home/${user}/id_ed25519.pub"',
+    '}',
+    '',
+    '',
+    '',
+    '',
+    ''
+  ],
+  assertions: [
     {
-        commentToken: '--',
-        description: '',
-        scope: 'source.dhall',
-        allowMiddleLineAssertions: false
-
+      testCaseLineNumber: 11,
+      sourceLineNumber: 9,
+      scopeAssertions: [
+        {
+          from: 4,
+          to: 5,
+          scopes: ['keyword.operator.record.begin.dhall'],
+          exclude: []
+        }
+      ]
     },
-    source:
-        ['',
-            '',
-            '{- Don\'t repeat yourself!',
-            '',
-            '   Repetition is error-prone',
-            '-}',
-            '',
-            '',
-            'let user = "bill"',
-            'in  { home       = "/home/${user}"',
-            '    , privateKey = "/home/${user}/id_ed25519"',
-            '    , publicKey  = "/home/${user}/id_ed25519.pub"',
-            '}',
-            '',
-            '',
-            '',
-            '',
-            ''],
-    assertions:
-        [{
-            testCaseLineNumber: 11,
-            sourceLineNumber: 9,
-            scopeAssertions:
-                [{
-                    from: 4,
-                    to: 5,
-                    scopes: ['keyword.operator.record.begin.dhall'],
-                    exclude: []
-                }]
+    {
+      testCaseLineNumber: 13,
+      sourceLineNumber: 10,
+      scopeAssertions: [
+        {
+          from: 6,
+          to: 16,
+          scopes: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'variable.object.property.dhall'
+          ],
+          exclude: []
         },
         {
-            testCaseLineNumber: 13,
-            sourceLineNumber: 10,
-            scopeAssertions:
-                [{
-                    from: 6,
-                    to: 16,
-                    scopes:
-                        ['source.dhall',
-                            'meta.declaration.data.record.block.dhall',
-                            'variable.object.property.dhall'],
-                    exclude: []
-                },
-                {
-                    "from": 17,
-                    "to": 18,
-                    "scopes": [
-                        "source.dhall",
-                        "meta.declaration.data.record.block.dhall",
-                        "meta.declaration.data.record.literal.dhall",
-                        "punctuation.separator.dictionary.key-value.dhall"
-                    ],
-                    exclude: []
-                },
-                {
-                    from: 19,
-                    to: 45,
-                    scopes: ['source.dhall', 'string.quoted.double.dhall'],
-                    exclude: []
-                }]
+          from: 17,
+          to: 18,
+          scopes: [
+            'source.dhall',
+            'meta.declaration.data.record.block.dhall',
+            'meta.declaration.data.record.literal.dhall',
+            'punctuation.separator.dictionary.key-value.dhall'
+          ],
+          exclude: []
         },
         {
-            testCaseLineNumber: 17,
-            sourceLineNumber: 11,
-            scopeAssertions:
-                [{
-                    from: 26,
-                    to: 33,
-                    scopes: ['constant.other.placeholder.dhall'],
-                    exclude: []
-                },
-                {
-                    from: 28, to: 32, scopes: ['meta.label.dhall'],
-                    exclude: []
-                }]
+          from: 19,
+          to: 45,
+          scopes: ['source.dhall', 'string.quoted.double.dhall'],
+          exclude: []
+        }
+      ]
+    },
+    {
+      testCaseLineNumber: 17,
+      sourceLineNumber: 11,
+      scopeAssertions: [
+        {
+          from: 26,
+          to: 33,
+          scopes: ['constant.other.placeholder.dhall'],
+          exclude: []
         },
         {
-            testCaseLineNumber: 20,
-            sourceLineNumber: 12,
-            scopeAssertions:
-                [{
-                    from: 0,
-                    to: 1,
-                    scopes: ['keyword.operator.record.end.dhall'],
-                    exclude: []
-                }]
-        }]
-}
+          from: 28,
+          to: 32,
+          scopes: ['meta.label.dhall'],
+          exclude: []
+        }
+      ]
+    },
+    {
+      testCaseLineNumber: 20,
+      sourceLineNumber: 12,
+      scopeAssertions: [
+        {
+          from: 0,
+          to: 1,
+          scopes: ['keyword.operator.record.end.dhall'],
+          exclude: []
+        }
+      ]
+    }
+  ]
+};

--- a/test/unit/unit/scopes.equal.test.ts
+++ b/test/unit/unit/scopes.equal.test.ts
@@ -1,35 +1,49 @@
 'use strict';
-import { expect } from 'chai'
+import { expect } from 'chai';
 
-import { missingScopes_ } from '../../../src/unit/index'
+import { missingScopes_ } from '../../../src/unit/index';
 
 // FIXME: move somewhere..
 describe('scopesEqual_', () => {
-    it('should return [] on two empty arrays', () => {
-        expect(missingScopes_([],[])).to.eql([]);
-    });
-    it('should return [] on empty requirements array', () => {
-        expect(missingScopes_([],['a', 'b', 'c'])).to.eql([]);
-    });
-    it('should return [] when requirements is a subset of a source array', () => {
-        expect(missingScopes_(['b', 'd', 'e'], ['a', 'b', 'c', 'd', 'e', 'f'])).to.eql([]);
-    });
-    it('should work with duplicate elements', () => {
-        expect(missingScopes_(['a', 'b', 'd', 'e'], ['a', 'a', 'a', 'b', 'c', 'd', 'e', 'f'])).to.eql([]);
-    });
-    it('should work with duplicate elements in requirements', () => {
-        expect(missingScopes_(['a', 'a', 'a', 'b', 'd', 'e'], ['a', 'a', 'a', 'b', 'c', 'd', 'e', 'f'])).to.eql([]);
-    });
-    it('should return [] when elements a bit misaligned', () => {
-        expect(missingScopes_(['b', 'c', 'a'], ['a', 'a', 'b', 'c', 'd', 'a', 'a', 'f'])).to.eql([]);
-    });
-    it('should return missing when actual array is empty', () => {
-        expect(missingScopes_(['b', 'c', 'a'], [])).to.eql(['b', 'c', 'a']);
-    });
-    it('should return missing when the arrays are different', () => {
-        expect(missingScopes_(['b', 'e', 'a'], ['b', 'c', 'a'])).to.eql(['e', 'a']);
-    });
-    it('should return missing when expected contains extra duplicate', () => {
-        expect(missingScopes_(['b', 'c', 'a', 'a'], ['b', 'c', 'a'])).to.eql(['a']);
-    });
+  it('should return [] on two empty arrays', () => {
+    expect(missingScopes_([], [])).to.eql([]);
+  });
+  it('should return [] on empty requirements array', () => {
+    expect(missingScopes_([], ['a', 'b', 'c'])).to.eql([]);
+  });
+  it('should return [] when requirements is a subset of a source array', () => {
+    expect(
+      missingScopes_(['b', 'd', 'e'], ['a', 'b', 'c', 'd', 'e', 'f'])
+    ).to.eql([]);
+  });
+  it('should work with duplicate elements', () => {
+    expect(
+      missingScopes_(
+        ['a', 'b', 'd', 'e'],
+        ['a', 'a', 'a', 'b', 'c', 'd', 'e', 'f']
+      )
+    ).to.eql([]);
+  });
+  it('should work with duplicate elements in requirements', () => {
+    expect(
+      missingScopes_(
+        ['a', 'a', 'a', 'b', 'd', 'e'],
+        ['a', 'a', 'a', 'b', 'c', 'd', 'e', 'f']
+      )
+    ).to.eql([]);
+  });
+  it('should return [] when elements a bit misaligned', () => {
+    expect(
+      missingScopes_(['b', 'c', 'a'], ['a', 'a', 'b', 'c', 'd', 'a', 'a', 'f'])
+    ).to.eql([]);
+  });
+  it('should return missing when actual array is empty', () => {
+    expect(missingScopes_(['b', 'c', 'a'], [])).to.eql(['b', 'c', 'a']);
+  });
+  it('should return missing when the arrays are different', () => {
+    expect(missingScopes_(['b', 'e', 'a'], ['b', 'c', 'a'])).to.eql(['e', 'a']);
+  });
+  it('should return missing when expected contains extra duplicate', () => {
+    expect(missingScopes_(['b', 'c', 'a', 'a'], ['b', 'c', 'a'])).to.eql(['a']);
+  });
 });

--- a/tslint.json
+++ b/tslint.json
@@ -2,9 +2,9 @@
 	"rules": {
 		"no-unused-expression": true,
 		"no-duplicate-variable": true,
-		"no-duplicate-key": true,
 		"curly": true,
 		"class-name": true,
-		"triple-equals": true
+		"triple-equals": true,
+		"no-consecutive-blank-lines": true
 	}
 }


### PR DESCRIPTION
To make it easier to work with the source, I thought it would be nice to have some consistent formatting and code style.
So I brought in prettier for code formatting as well as removed a few instances of commented out or unused code.

It would be nice to get some feedback on the formatter configs and specifics in the `.prettierrc` file