### PR TITLE
Add --validate option to vscode-tmgrammar-test

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ Options:
   -s, --scope <scope>      Language scope, e.g. source.dhall
   -g, --grammar <grammar>  Path to a grammar file, either .json or .xml. This option can be specified multiple times if multiple grammar needed. (default: [])
   -t, --testcases <glob>   A glob pattern which specifies testcases to run, e.g. "./tests/**/test*.dhall". Quotes are important!
+  -v, --validate           Validate the grammar file for well-formedness and pattern validity instead of running testcases.
   -c, --compact            Display output in the compact format, which is easier to use with VSCode problem matchers
   -h, --help               output usage information
 ```

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -36,6 +36,10 @@ program
     'A glob pattern which specifies testcases to run, e.g. "./tests/**/test*.dhall". Quotes are important!'
   )
   .option(
+    '-v, --validate',
+    'Validate the grammar file for well-formedness and pattern validity instead of running testcases.'
+  )
+  .option(
     '-c, --compact',
     'Display output in the compact format, which is easier to use with VSCode problem matchers'
   )
@@ -45,7 +49,10 @@ if (
   program.scope === undefined ||
   program.grammar === undefined ||
   program.grammar.length === 0 ||
-  program.testcases === undefined
+  (
+    program.testcases === undefined &&
+    program.validate === undefined
+  )
 ) {
   program.help();
 }
@@ -77,6 +84,10 @@ const TestSuccessful = 0;
 const Padding = '  ';
 
 const registry = createRegistry(program.grammar);
+
+if (program.validate && !!registry && typeof registry === 'object') {
+  process.exit(0);
+}
 
 function printSourceLine(testCase: GrammarTestCase, failure: TestFailure) {
   const line = testCase.source[failure.srcLine];

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -85,8 +85,12 @@ const Padding = '  ';
 
 const registry = createRegistry(program.grammar);
 
-if (program.validate && !!registry && typeof registry === 'object') {
-  process.exit(0);
+if (program.validate) {
+  if (!!registry && typeof registry === 'object') {
+    process.exit(0);
+  } else {
+    process.exit(1);
+  }
 }
 
 function printSourceLine(testCase: GrammarTestCase, failure: TestFailure) {


### PR DESCRIPTION
Closes #26. Untested, and can't handle grammar globs either.