### PR TITLE
Fix broken windows tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -5,9 +5,13 @@ name: Node.js CI
 
 on:
   push:
-    branches: [ master ]
+    tags:
+      - '*'
+    branches:
+      - '*'
   pull_request:
-    branches: [ master ]
+    branches:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -12,11 +12,12 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node-version: [10.x, 12.x]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
     - uses: actions/checkout@v2

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,24 @@
             "outFiles": [
                 "${workspaceFolder}/**/*.js"
             ]
-        }
+        }, {
+            "name": "Debug Tests",
+            "type": "node",
+            "request": "launch",
+            "smartStep": false,
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+              "-r",
+              "ts-node/register",
+              "-r",
+              "source-map-support/register",
+              "test/**/*.test.ts",
+              "--timeout",
+              "500000"
+            ],
+            "cwd": "${workspaceRoot}",
+            "protocol": "inspector",
+            "internalConsoleOptions": "openOnSessionStart"
+          }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -27,7 +27,6 @@
                         "column": 4,
                         "endColumn": 5,
                         "message": 6
-                        
                     }
                 ]
             }
@@ -35,6 +34,18 @@
         {
             "type": "npm",
             "script": "build",
+            "problemMatcher": [
+                "$tsc"
+            ]
+        },
+        {
+            "label": "test",
+            "type": "npm",
+            "script": "test",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
             "problemMatcher": [
                 "$tsc"
             ]

--- a/test/functional/snaps.test.ts
+++ b/test/functional/snaps.test.ts
@@ -2,6 +2,7 @@ import child_process from 'child_process';
 import { expect } from 'chai';
 import fs from 'fs';
 import util from 'util';
+import { normalize } from '../helpers.test';
 
 const exec = util.promisify(child_process.exec);
 
@@ -9,18 +10,20 @@ const exec = util.promisify(child_process.exec);
 describe('snap test', () => {
   const root = process.cwd();
 
-  it('should report OK for test without errors', () => {
+  it('should report OK for test without errors', async () => {
     return exec(
-      `node ${root}/dist/src/snapshot.js \\
-      --scope source.dhall \\
-      --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/snap-ok-scenario/simple.dhall`,
+      `node ${root}/dist/src/snapshot.js ` +
+      `--scope source.dhall ` +
+      `--grammar ${root}/test/resources/dhall.tmLanguage.json ` +
+      `-t ${__dirname}/resources/snap-ok-scenario/simple.dhall`,
       {
         cwd: root
       }
     ).then(({ stdout, stderr }) => {
-      expect(stdout).to.eq(
-        `✓ ${root}/test/functional/resources/snap-ok-scenario/simple.dhall run successfully.\n`
+      expect(
+        normalize(stdout)
+      ).to.eq(
+        normalize(`✓ ${root}/test/functional/resources/snap-ok-scenario/simple.dhall run successfully.`)
       );
       expect(stderr).to.eq('');
     });
@@ -28,10 +31,10 @@ describe('snap test', () => {
 
   it('should report wrong or missing scopes', () => {
     return exec(
-      `node ${root}/dist/src/snapshot.js  \\
-      --scope source.dhall \\
-      --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/snap-simple-failure/simple.dhall`,
+      `node ${root}/dist/src/snapshot.js ` +
+      `--scope source.dhall ` +
+      `--grammar ${root}/test/resources/dhall.tmLanguage.json ` +
+      `-t ${__dirname}/resources/snap-simple-failure/simple.dhall`,
       {
         cwd: root
       }
@@ -42,13 +45,17 @@ describe('snap test', () => {
       .catch(({ stdout, stderr }) => {
         // fs.writeFileSync('stderr.txt', stderr)
         //  fs.writeFileSync('stdout.txt', stdout)
-        expect(stdout).to.eq(
-          fs
-            .readFileSync(
-              `${__dirname}/resources/snap-simple-failure/stdout.txt`
-            )
-            .toString()
-            .replace(/<root>/, root)
+        expect(
+          normalize(stdout)
+        ).to.eq(
+          normalize(
+            fs
+              .readFileSync(
+                `${__dirname}/resources/snap-simple-failure/stdout.txt`
+              )
+              .toString()
+              .replace(/<root>/, root)
+          )
         );
       });
   });
@@ -59,27 +66,29 @@ describe('snap test', () => {
       `${__dirname}/resources/snap-update-snapshot/simple.dhall.snap`
     );
     await exec(
-      `node ${root}/dist/src/snapshot.js  \\
-      --scope source.dhall \\
-      --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/snap-update-snapshot/simple.dhall \\
-      --updateSnapshot`,
+      `node ${root}/dist/src/snapshot.js ` +
+      `--scope source.dhall ` +
+      `--grammar ${root}/test/resources/dhall.tmLanguage.json ` +
+      `-t ${__dirname}/resources/snap-update-snapshot/simple.dhall ` +
+      `--updateSnapshot`,
       {
         cwd: root
       }
     );
 
     await exec(
-      `node ${root}/dist/src/snapshot.js  \\
-      --scope source.dhall \\
-      --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/snap-update-snapshot/simple.dhall`,
+      `node ${root}/dist/src/snapshot.js ` +
+      `--scope source.dhall `+
+      `--grammar ${root}/test/resources/dhall.tmLanguage.json `+
+      `-t ${__dirname}/resources/snap-update-snapshot/simple.dhall`,
       {
         cwd: root
       }
     ).then(({ stdout, stderr }) => {
-      expect(stdout).to.eq(
-        `✓ ${root}/test/functional/resources/snap-update-snapshot/simple.dhall run successfully.\n`
+      expect(
+        normalize(stdout)
+      ).to.eq(
+        normalize(`✓ ${root}/test/functional/resources/snap-update-snapshot/simple.dhall run successfully.\n`)
       );
       expect(stderr).to.eq('');
     });

--- a/test/functional/unit-tests.test.ts
+++ b/test/functional/unit-tests.test.ts
@@ -2,6 +2,7 @@ import child_process from 'child_process';
 import { expect } from 'chai';
 import fs from 'fs';
 import util from 'util';
+import { normalize } from '../helpers.test';
 
 const exec = util.promisify(child_process.exec);
 
@@ -11,27 +12,28 @@ describe('unit test', () => {
 
   it('should report OK for test without errors', () => {
     return exec(
-      `node ${root}/dist/src/unit.js \\
-      --scope source.dhall \\
-      --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/unit-ok-scenario/success.dhall`,
+      `node ${root}/dist/src/unit.js ` +
+      `--scope source.dhall ` +
+      `--grammar ${root}/test/resources/dhall.tmLanguage.json ` +
+      `-t ${__dirname}/resources/unit-ok-scenario/success.dhall`,
       {
         cwd: root
-      }
-    ).then(({ stdout, stderr }) => {
-      expect(stdout).to.eq(
-        `✓ ${root}/test/functional/resources/unit-ok-scenario/success.dhall run successfuly.\n`
-      );
-      expect(stderr).to.eq('');
-    });
+      }).then(({ stdout, stderr }) => {
+        expect(
+          normalize(stdout.trim())
+        ).to.eql(
+          normalize(`✓ ${root}/test/functional/resources/unit-ok-scenario/success.dhall run successfuly.`)
+        );
+        expect(stderr).to.eq('');
+      });
   });
 
   it('should report Unexpected scopes', () => {
     return exec(
-      `node ${root}/dist/src/unit.js  \\
-      --scope source.dhall \\
-      --grammar ${root}/test/resources/dhall.tmLanguage.json \\
-      -t ${__dirname}/resources/unit-report-unexpected-scopes/unexpected.scopes.test.dhall`,
+      `node ${root}/dist/src/unit.js  ` +
+      `--scope source.dhall ` +
+      `--grammar ${root}/test/resources/dhall.tmLanguage.json ` +
+      `-t ${__dirname}/resources/unit-report-unexpected-scopes/unexpected.scopes.test.dhall`,
       {
         cwd: root
       }
@@ -42,13 +44,17 @@ describe('unit test', () => {
       .catch(({ stdout, stderr }) => {
         // fs.writeFileSync('stderr.txt', stderr)
         // fs.writeFileSync('stdout.text', stdout)
-        expect(stdout).to.deep.equal(
-          fs
-            .readFileSync(
-              `${__dirname}/resources/unit-report-unexpected-scopes/stdout.txt`
-            )
-            .toString()
-            .replace(/<root>/g, root)
+        expect(
+          normalize(stdout)
+        ).to.deep.equal(
+          normalize(
+            fs
+              .readFileSync(
+                `${__dirname}/resources/unit-report-unexpected-scopes/stdout.txt`
+              )
+              .toString()
+              .replace(/<root>/g, root)
+          )
         );
       });
   });

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Normalize various items in the unit tests, such as:
+ *  - line endings
+ *  - path separators
+ *  - ascii symbols (checkmark, x, etc...).
+ */
+export function normalize(text: string) {
+    if (!text) {
+        return text;
+    }
+    return text
+        //normalize path separators
+        .replace(/[\/\\]+/g, '/')
+        //normalize line endings
+        .replace(/\r?\n/g, '\n')
+        //checkmark
+        .replace(new RegExp('\u221A', 'g'), '✓')
+        //x
+        .replace(new RegExp('\u00D7', 'g'), '✖')
+        //remove excess leading and trailing whitespace (including newlines)
+        .trim();
+}

--- a/test/unit/unit/parsing.test.ts
+++ b/test/unit/unit/parsing.test.ts
@@ -7,6 +7,7 @@ import {
   parseScopeAssertion,
   parseGrammarTestCase
 } from '../../../src/unit/parsing';
+import { EOL } from 'os';
 
 describe('parseHeader', () => {
   it('should parse one character comment token', () => {
@@ -43,8 +44,8 @@ describe('parseHeader', () => {
   });
   it('should throw meaningful error msg', () => {
     expect(parseHeader.bind({}, ['-- SYNTAX TEST sql"'])).to.throw(
-      'Expecting the first line in the syntax test file to be in the following format:\n' +
-        '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?'
+      `Expecting the first line in the syntax test file to be in the following format:${EOL}` +
+      '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?'
     );
   });
 });
@@ -188,16 +189,16 @@ describe('parseScopeAssertion', () => {
   });
   it('should throw an error for an empty <- ', () => {
     expect(() => parseScopeAssertion(0, 1, '#<-- - ')).to.throw(
-      'Inalid assertion at line 0:\n' +
-        '#<-- - \n' +
-        ' Missing both required and prohibited scopes'
+      `Inalid assertion at line 0:${EOL}` +
+      `#<-- - ${EOL}` +
+      ` Missing both required and prohibited scopes`
     );
   });
   it('should throw an error on empty ^ ', () => {
     expect(() => parseScopeAssertion(0, 1, '# ^^^ ')).to.throw(
-      'Inalid assertion at line 0:\n' +
-        '# ^^^ \n' +
-        ' Missing both required and prohibited scopes'
+      `Inalid assertion at line 0:${EOL}` +
+      `# ^^^ ${EOL}` +
+      ` Missing both required and prohibited scopes`
     );
   });
 });
@@ -216,7 +217,7 @@ describe('parseGrammarTestCase', () => {
     let originalFile = fs
       .readFileSync('./test/resources/parser.test.dhall')
       .toString();
-    let crlfFile = originalFile.split('\n').join('\r\n');
+    let crlfFile = originalFile.replace(/\r?\n/g, '\n');
     expect(parseGrammarTestCase(crlfFile)).to.eql(
       parserTestDhallExpectedResult
     );


### PR DESCRIPTION
I fixed the failing windows unit tests, and added a few housekeeping items. Let me know if you want me to move any of the miscellaneous items into their own pull requests.

- Fixes unit tests that are current failing on Windows environments. 
- adds `windows-latest` and `macos-latest` to CI builds
- run the github actions on all pull requests and branches to ensure failing tests are caught quickly in the future.
- adds vscode launch configuration for debugging tests
- adds vscode test task which can be run with this command pallet action (and assigned to a keyboard shortcut!)
![image](https://user-images.githubusercontent.com/2544493/159062572-9fd232f0-dd7c-4b09-99fb-0dacc6fdd250.png)


