### PR TITLE
 add option --xunit-report to emit xml report files

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Tests",
+            "type": "node",
+            "request": "launch",
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "npm",
+            "runtimeArgs": [
+                "run-script",
+                "test"
+            ],
+            "autoAttachChildProcesses": true
+        }
+    ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,13 +26,15 @@
         "@types/glob": "^7.1.1",
         "@types/mocha": "^5.2.7",
         "@types/node": "^12.12.37",
+        "@types/xml2js": "^0.4.11",
         "chai": "^4.2.0",
         "mocha": "^10.2.0",
         "nyc": "^15.0.1",
         "prettier": "^2.1.2",
         "ts-node": "^8.10.2",
         "tslint": "^5.20.1",
-        "typescript": "^3.8.3"
+        "typescript": "^3.8.3",
+        "xml2js": "^0.6.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -496,6 +498,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
       "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
       "dev": true
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.11.tgz",
+      "integrity": "sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
@@ -2394,6 +2405,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -2832,6 +2849,28 @@
         "is-typedarray": "^1.0.0",
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+      "dev": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/y18n": {
@@ -3301,6 +3340,15 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.50.tgz",
       "integrity": "sha512-+9axpWx2b2JCVovr7Ilgt96uc6C1zBKOQMpGtRbWT9IoR/8ue32GGMfGA4woP8QyP2gBs6GQWEVM3tCybGCxDA==",
       "dev": true
+    },
+    "@types/xml2js": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.11.tgz",
+      "integrity": "sha512-JdigeAKmCyoJUiQljjr7tQG3if9NkqGUgwEUqBvV0N7LM4HyQk7UXCnusRa1lnvXAEYJ8mw8GtZWioagNztOwA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "aggregate-error": {
       "version": "3.1.0",
@@ -4698,6 +4746,12 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+      "dev": true
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -5032,6 +5086,22 @@
         "signal-exit": "^3.0.2",
         "typedarray-to-buffer": "^3.1.5"
       }
+    },
+    "xml2js": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+      "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+      "dev": true,
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -38,13 +38,15 @@
     "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.37",
+    "@types/xml2js": "^0.4.11",
     "chai": "^4.2.0",
     "mocha": "^10.2.0",
     "nyc": "^15.0.1",
     "prettier": "^2.1.2",
     "ts-node": "^8.10.2",
     "tslint": "^5.20.1",
-    "typescript": "^3.8.3"
+    "typescript": "^3.8.3",
+    "xml2js": "^0.6.0"
   },
   "dependencies": {
     "chalk": "^2.4.2",

--- a/src/unit.ts
+++ b/src/unit.ts
@@ -1,14 +1,14 @@
 #!/usr/bin/env node
 
 import * as fs from 'fs'
-import * as tty from 'tty'
 import chalk from 'chalk'
 import { program } from 'commander'
 import glob from 'glob'
-import { EOL } from 'os'
 import { runGrammarTestCase, parseGrammarTestCase, GrammarTestCase, TestFailure } from './unit/index'
+import { Reporter, ConsoleCompactReporter, ConsoleFullReporter, XunitReporter, CompositeReporter } from './unit/reporter'
 
 import { createRegistry, loadConfiguration, IGrammarConfig } from './common/index'
+
 
 let packageJson = require('../package.json')
 
@@ -26,6 +26,7 @@ program
   )
   .option('--config <configuration.json>', 'Path to the language configuration, package.json by default')
   .option('-c, --compact', 'Display output in the compact format, which is easier to use with VSCode problem matchers')
+  .option('--xunit-report <report.xml>', 'Path to directory where test reports in the XUnit format will be emitted in addition to console output')
   .version(packageJson.version)
   .argument(
     '<testcases...>',
@@ -35,31 +36,9 @@ program
 
 const options = program.opts()
 
-let isatty = tty.isatty(1) && tty.isatty(2)
-
-const symbols = {
-  ok: '✓',
-  err: '✖',
-  dot: '․',
-  comma: ',',
-  bang: '!'
-}
-
-if (process.platform === 'win32') {
-  symbols.ok = '\u221A'
-  symbols.err = '\u00D7'
-  symbols.dot = '.'
-}
-
-let terminalWidth = 75
-
-if (isatty) {
-  terminalWidth = (process.stdout as tty.WriteStream).getWindowSize()[0]
-}
 
 const TestFailed = -1
 const TestSuccessful = 0
-const Padding = '  '
 
 let { grammars } = loadConfiguration(options.config, options.scope, options.grammar)
 const registry = createRegistry(grammars)
@@ -72,7 +51,13 @@ if (options.validate) {
   }
 }
 
-const displayTestResult = options.compact ? displayTestResultCompact : displayTestResultFull
+
+const consoleReporter = options.compact 
+  ? new ConsoleCompactReporter() 
+  : new ConsoleFullReporter()
+const reporter: Reporter  = options.xunitReport
+  ? new CompositeReporter(consoleReporter, new XunitReporter(options.xunitReport))
+  : consoleReporter
 
 const rawTestCases = program.args.map((x) => glob.sync(x)).flat()
 
@@ -87,8 +72,7 @@ const testResults: Promise<number[]> = Promise.all(
     try {
       tc = parseGrammarTestCase(fs.readFileSync(filename).toString())
     } catch (error) {
-      console.log(chalk.red('ERROR') + " can't parse testcase: " + chalk.whiteBright(filename) + '')
-      console.log(error)
+      reporter.reportParseError(filename, error)
       return new Promise((resolve, reject) => {
         resolve(TestFailed)
       })
@@ -96,15 +80,18 @@ const testResults: Promise<number[]> = Promise.all(
     let testCase = tc as GrammarTestCase
     return runGrammarTestCase(registry, testCase)
       .then((failures) => {
-        return displayTestResult(filename, testCase, failures)
+        reporter.reportTestResult(filename, testCase, failures)
+        return failures.length === 0 ? TestSuccessful : TestFailed
       })
       .catch((error: any) => {
-        return handleGrammarTestError(filename, testCase, error)
+        reporter.reportGrammarTestError(filename, testCase, error)
+        return TestFailed
       })
   })
 )
 
 testResults.then((xs) => {
+  reporter.reportSuiteResult()
   const result = xs.reduce((a, b) => a + b, 0)
   if (result === TestSuccessful) {
     process.exit(0)
@@ -112,99 +99,3 @@ testResults.then((xs) => {
     process.exit(-1)
   }
 })
-
-function printSourceLine(testCase: GrammarTestCase, failure: TestFailure) {
-  const line = testCase.source[failure.srcLine]
-  const pos = failure.line + 1 + ': '
-  const accents = ' '.repeat(failure.start) + '^'.repeat(failure.end - failure.start)
-
-  const termWidth = terminalWidth - pos.length - Padding.length - 5
-
-  const trimLeft = failure.end > termWidth ? Math.max(0, failure.start - 8) : 0
-
-  const line1 = line.substr(trimLeft)
-  const accents1 = accents.substr(trimLeft)
-
-  console.log(Padding + chalk.gray(pos) + line1.substr(0, termWidth))
-  console.log(Padding + ' '.repeat(pos.length) + accents1.substr(0, termWidth))
-}
-
-function printReason(testCase: GrammarTestCase, failure: TestFailure) {
-  if (failure.missing && failure.missing.length > 0) {
-    console.log(chalk.red(Padding + 'missing required scopes: ') + chalk.gray(failure.missing.join(' ')))
-  }
-  if (failure.unexpected && failure.unexpected.length > 0) {
-    console.log(chalk.red(Padding + 'prohibited scopes: ') + chalk.gray(failure.unexpected.join(' ')))
-  }
-  if (failure.actual !== undefined) {
-    console.log(chalk.red(Padding + 'actual: ') + chalk.gray(failure.actual.join(' ')))
-  }
-}
-
-function displayTestResultFull(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): number {
-  if (failures.length === 0) {
-    console.log(chalk.green(symbols.ok) + ' ' + chalk.whiteBright(filename) + ` run successfuly.`)
-    return TestSuccessful
-  } else {
-    console.log(chalk.red(symbols.err + ' ' + filename + ' failed'))
-    failures.forEach((failure) => {
-      const { l, s, e } = getCorrectedOffsets(failure)
-      console.log(Padding + 'at [' + chalk.whiteBright(`${filename}:${l}:${s}:${e}`) + ']:')
-      printSourceLine(testCase, failure)
-      printReason(testCase, failure)
-
-      console.log(EOL)
-    })
-    console.log('')
-    return TestFailed
-  }
-}
-
-function renderCompactErrorMsg(testCase: GrammarTestCase, failure: TestFailure): string {
-  let res = ''
-  if (failure.missing && failure.missing.length > 0) {
-    res += `Missing required scopes: [ ${failure.missing.join(' ')} ] `
-  }
-  if (failure.unexpected && failure.unexpected.length > 0) {
-    res += `Prohibited scopes: [ ${failure.unexpected.join(' ')} ] `
-  }
-  if (failure.actual !== undefined) {
-    res += `actual scopes: [${failure.actual.join(' ')}]`
-  }
-  return res
-}
-
-function displayTestResultCompact(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): number {
-  if (failures.length === 0) {
-    console.log(chalk.green(symbols.ok) + ' ' + chalk.whiteBright(filename) + ` run successfuly.`)
-    return TestSuccessful
-  } else {
-    failures.forEach((failure) => {
-      console.log(
-        `ERROR ${filename}:${failure.line + 1}:${failure.start + 1}:${failure.end + 1} ${renderCompactErrorMsg(
-          testCase,
-          failure
-        )}`
-      )
-    })
-    return TestFailed
-  }
-}
-
-function handleGrammarTestError(filename: string, testCase: GrammarTestCase, reason: any): number {
-  console.log(chalk.red(symbols.err) + ' testcase ' + chalk.gray(filename) + ' aborted due to an error')
-  console.log(reason)
-  return TestFailed
-}
-
-function getCorrectedOffsets(failure: TestFailure): {
-  l: number
-  s: number
-  e: number
-} {
-  return {
-    l: failure.line + 1,
-    s: failure.start + 1,
-    e: failure.end + 1
-  }
-}

--- a/src/unit/reporter.ts
+++ b/src/unit/reporter.ts
@@ -1,0 +1,336 @@
+import chalk from 'chalk'
+import * as fs from 'fs'
+import * as p from 'path'
+import * as tty from 'tty'
+import { EOL } from 'os'
+import { GrammarTestCase, LineAssertion, TestFailure } from "./model"
+
+export interface Reporter {
+    reportTestResult(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): void
+    reportParseError(filename: string, error: any): void
+    reportGrammarTestError(filename: string, testCase: GrammarTestCase, reason: any): void
+    reportSuiteResult(): void
+}
+
+export class CompositeReporter implements Reporter {
+
+    private reporters: Reporter[]
+
+    constructor(...reporters: Reporter[]) {
+        this.reporters = reporters
+    }
+
+    reportTestResult(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): void {
+        this.reporters.forEach(r => r.reportTestResult(filename, testCase, failures))
+    }
+    reportGrammarTestError(filename: string, testCase: GrammarTestCase, reason: any): void {
+        this.reporters.forEach(r => r.reportGrammarTestError(filename, testCase, reason))
+    }
+
+    reportParseError(filename: string, error: any): void {
+        this.reporters.forEach(r => r.reportParseError(filename, error))
+    }
+
+    reportSuiteResult(): void {
+        this.reporters.forEach(r => r.reportSuiteResult())
+    }
+}
+
+interface XunitSuite {
+    readonly file: string
+    readonly name: string
+    readonly cases: XunitCase[]
+}
+
+interface XunitCase {
+    readonly name: string
+    readonly failures: XunitFailure[]
+}
+
+interface XunitFailure {
+    readonly type: 'error' | 'failure'
+    readonly message: string
+    readonly body: string
+}
+
+export class XunitReporter implements Reporter, Colorizer {
+    // follows this schema https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd and produces one report file per test file
+    // if some CI requires single report file may also implement reporter for this format https://github.com/windyroad/JUnit-Schema/blob/master/JUnit.xsd
+    private suites: XunitSuite[] = []
+
+    constructor(private reportPath: string) { }
+
+    reportTestResult(filename: string, parsedFile: GrammarTestCase, failures: TestFailure[]): void {
+        const suite = this.getSuite(filename, parsedFile)
+
+        // source line in the test file is treated as testcase
+        // and every failed assertion associated with this source line is failure in that testcase
+
+        for (const assertion of parsedFile.assertions) {
+            const c = this.getCase(suite, filename, assertion);
+            for (const failure of failures) {
+                if (failure.line !== assertion.testCaseLineNumber) {
+                    continue
+                }
+                const { l, s, e } = getCorrectedOffsets(failure)
+
+                const bodyLines: string[] = []
+                printSourceLine(parsedFile, failure, 200, m => bodyLines.push(m), this)
+                printReason(parsedFile, failure, m => bodyLines.push(m), this)
+                const body = this.escapedXml(bodyLines.join("\n"))
+                c.failures.push({
+                    type: 'failure',
+                    message: `Assertion failed at ${l}:${s}:${e}`,
+                    body
+                })
+            }
+        }
+    }
+
+    escapedXml(raw: string): string {
+        return raw
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&apos;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+    }
+
+    reportParseError(filename: string, error: any): void {
+        const suite = this.getSuite(filename)
+        suite.cases.push({
+            name: "Parse test file",
+            failures: [{
+                type: 'error',
+                message: "Failed to parse test file",
+                body: JSON.stringify(error)
+            }]
+        })
+    }
+
+    reportGrammarTestError(filename: string, parsedFile: GrammarTestCase, reason: any): void {
+        const suite = this.getSuite(filename, parsedFile)
+        suite.cases.push({
+            name: "Run grammar tests",
+            failures: [{
+                type: 'error',
+                message: "Error when running grammar tests",
+                body: JSON.stringify(reason)
+            }]
+        })
+    }
+
+    red(text: string): string {
+        return text
+    }
+    gray(text: string): string {
+        return text
+    }
+
+    private getSuite(filename: string, parsedFile?: GrammarTestCase): XunitSuite {
+        const suite: XunitSuite = {
+            file: `TEST-${filename.replace(/\//g, '.')}.xml`,
+            name: parsedFile?.metadata.description || filename,
+            cases: []
+        }
+        this.suites.push(suite)
+        return suite
+    }
+
+    private getCase(suite: XunitSuite, filename: string, assertion: LineAssertion): XunitCase {
+        const name = `${filename}:${assertion.sourceLineNumber + 1}`
+        for (const c of suite.cases) {
+            if (c.name === name) {
+                return c
+            }
+        }
+        const c: XunitCase = {
+            name, failures: []
+        }
+        suite.cases.push(c)
+        return c
+    }
+
+    reportSuiteResult(): void {
+        fs.mkdirSync(this.reportPath, { recursive: true })
+        for (const suite of this.suites.values()) {
+            fs.writeFileSync(p.resolve(this.reportPath, suite.file), this.renderSuite(suite))
+        }
+    }
+    renderSuite(s: XunitSuite): string {
+        return `
+<testsuite 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd"
+    name="${s.name}"
+    tests="${s.cases.length}"
+    failures="${s.cases.reduce((accSuite, c) => accSuite + c.failures.reduce((accCase, f) => accCase + (f.type === 'failure' ? 1 : 0), 0), 0)}"
+    errors="${s.cases.reduce((accSuite, c) => accSuite + c.failures.reduce((accCase, f) => accCase + (f.type === 'error' ? 1 : 0), 0), 0)}"
+    skipped="0"
+>${s.cases.reduce((a, c) => a + "\n" + this.renderCase(c), "")}
+</testsuite>
+`
+    }
+
+    renderCase(c: XunitCase): string {
+        return `  <testcase name="${c.name}" time="0">${c.failures.reduce((a, f) => a + "\n" + this.renderFailure(f), "")}${this.newlineIfHasItems(c.failures)}</testcase>`
+    }
+
+    renderFailure(f: XunitFailure): string {
+        return `    <${f.type} message="${f.message}" type="${f.type === 'failure' ? 'TestFailure' : 'GrammarTestError'}">${f.body}</${f.type}>`
+    }
+
+    newlineIfHasItems(arr: any[]): string {
+        return arr.length === 0 ? "" : "\n"
+    }
+}
+
+const symbols = {
+    ok: '✓',
+    err: '✖',
+    dot: '․',
+    comma: ',',
+    bang: '!'
+}
+
+if (process.platform === 'win32') {
+    symbols.ok = '\u221A'
+    symbols.err = '\u00D7'
+    symbols.dot = '.'
+}
+
+const Padding = '  '
+
+let isatty = tty.isatty(1) && tty.isatty(2)
+let terminalWidth = 75
+
+if (isatty) {
+    terminalWidth = (process.stdout as tty.WriteStream).getWindowSize()[0]
+}
+
+function handleGrammarTestError(filename: string, testCase: GrammarTestCase, reason: any): void {
+    console.log(chalk.red(symbols.err) + ' testcase ' + chalk.gray(filename) + ' aborted due to an error')
+    console.log(reason)
+}
+
+function handleParseError(filename: string, error: any): void {
+    console.log(chalk.red('ERROR') + " can't parse testcase: " + chalk.whiteBright(filename) + '')
+    console.log(error)
+}
+
+export class ConsoleCompactReporter implements Reporter {
+
+    reportTestResult(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): void {
+        if (failures.length === 0) {
+            console.log(chalk.green(symbols.ok) + ' ' + chalk.whiteBright(filename) + ` run successfuly.`)
+        } else {
+            failures.forEach((failure) => {
+                console.log(
+                    `ERROR ${filename}:${failure.line + 1}:${failure.start + 1}:${failure.end + 1} ${this.renderCompactErrorMsg(
+                        testCase,
+                        failure
+                    )}`
+                )
+            })
+        }
+    }
+
+    renderCompactErrorMsg(testCase: GrammarTestCase, failure: TestFailure): string {
+        let res = ''
+        if (failure.missing && failure.missing.length > 0) {
+            res += `Missing required scopes: [ ${failure.missing.join(' ')} ] `
+        }
+        if (failure.unexpected && failure.unexpected.length > 0) {
+            res += `Prohibited scopes: [ ${failure.unexpected.join(' ')} ] `
+        }
+        if (failure.actual !== undefined) {
+            res += `actual scopes: [${failure.actual.join(' ')}]`
+        }
+        return res
+    }
+
+    reportParseError = handleParseError
+
+    reportGrammarTestError = handleGrammarTestError
+
+    reportSuiteResult(): void { }
+}
+
+
+export class ConsoleFullReporter implements Reporter {
+
+    reportTestResult(filename: string, testCase: GrammarTestCase, failures: TestFailure[]): void {
+        if (failures.length === 0) {
+            console.log(chalk.green(symbols.ok) + ' ' + chalk.whiteBright(filename) + ` run successfuly.`)
+        } else {
+            console.log(chalk.red(symbols.err + ' ' + filename + ' failed'))
+            failures.forEach((failure) => {
+                const { l, s, e } = getCorrectedOffsets(failure)
+                console.log(Padding + 'at [' + chalk.whiteBright(`${filename}:${l}:${s}:${e}`) + ']:')
+                printSourceLine(testCase, failure, terminalWidth, console.log, chalk)
+                printReason(testCase, failure, console.log, chalk)
+
+                console.log(EOL)
+            })
+            console.log('')
+        }
+    }
+
+    reportParseError = handleParseError
+
+    reportGrammarTestError = handleGrammarTestError
+
+    reportSuiteResult(): void { }
+}
+
+function getCorrectedOffsets(failure: TestFailure): {
+    l: number
+    s: number
+    e: number
+} {
+    return {
+        l: failure.line + 1,
+        s: failure.start + 1,
+        e: failure.end + 1
+    }
+}
+
+function printSourceLine(
+    testCase: GrammarTestCase, failure: TestFailure,
+    terminalWidth: number,
+    sink: (message: string) => void, colorizer: Colorizer
+) {
+    const line = testCase.source[failure.srcLine]
+    const pos = failure.line + 1 + ': '
+    const accents = ' '.repeat(failure.start) + '^'.repeat(failure.end - failure.start)
+
+    const termWidth = terminalWidth - pos.length - Padding.length - 5
+
+    const trimLeft = failure.end > termWidth ? Math.max(0, failure.start - 8) : 0
+
+    const line1 = line.substr(trimLeft)
+    const accents1 = accents.substr(trimLeft)
+
+    sink(Padding + colorizer.gray(pos) + line1.substr(0, termWidth))
+    sink(Padding + ' '.repeat(pos.length) + accents1.substr(0, termWidth))
+}
+
+function printReason(
+    testCase: GrammarTestCase, failure: TestFailure,
+    sink: (message: string) => void, colorizer: Colorizer
+) {
+    if (failure.missing && failure.missing.length > 0) {
+        sink(colorizer.red(Padding + 'missing required scopes: ') + colorizer.gray(failure.missing.join(' ')))
+    }
+    if (failure.unexpected && failure.unexpected.length > 0) {
+        sink(colorizer.red(Padding + 'prohibited scopes: ') + colorizer.gray(failure.unexpected.join(' ')))
+    }
+    if (failure.actual !== undefined) {
+        sink(colorizer.red(Padding + 'actual: ') + colorizer.gray(failure.actual.join(' ')))
+    }
+}
+
+interface Colorizer {
+    red(text: string): string;
+    gray(text: string): string
+}

--- a/test/unit/unit/reporter.test.ts
+++ b/test/unit/unit/reporter.test.ts
@@ -4,276 +4,393 @@ import * as fs from 'fs'
 import * as p from 'path'
 import { parseStringPromise } from 'xml2js'
 
-import { XunitReporter } from '../../../src/unit/reporter'
+import { Reporter, XunitGenericReporter, XunitGitlabReporter } from '../../../src/unit/reporter'
 import { LineAssertion, TestCaseMetadata, TestFailure } from '../../../src/unit/model'
 
-describe('XUnit reporter', () => {
+describe('XUnit reporters', () => {
 
     let reportsDir: string
-    let reporter: XunitReporter
 
     beforeEach(() => {
         reportsDir = fs.mkdtempSync("/tmp/reports_")
-        reporter = new XunitReporter(reportsDir)
     })
 
     afterEach(() => {
         fs.rmdirSync(reportsDir, { recursive: true })
     })
 
-    it('should emit one report file per test file', async () => {
-        reporter.reportTestResult('file1', {
-            source: ['source1'],
-            metadata: metadata('case 1 description'),
-            assertions: [
-                lineAssertion(71),
-                lineAssertion(82),
-            ]
-        }, [])
-        reporter.reportTestResult('file2', {
-            source: ['source2'],
-            metadata: metadata(),
-            assertions: [
-                lineAssertion(93),
-            ]
-        }, [])
-        reporter.reportSuiteResult()
+    describe('Generic XUnit reporter', () => {
 
-        assertReportFiles(
-            'TEST-file1.xml',
-            'TEST-file2.xml'
-        )
+        let reporter: Reporter
 
-        const xml1 = await readReport('TEST-file1.xml')
-        expect(xml1.testsuite.$.name).eq('case 1 description')
-        expect(xml1.testsuite.$.tests).eq('2')
-        expect(xml1.testsuite.$.failures).eq('0')
-        expect(xml1.testsuite.testcase).length(2)
-        expect(xml1.testsuite.testcase[0].$.name).eq('file1:71')
-        expect(xml1.testsuite.testcase[1].$.name).eq('file1:82')
+        beforeEach(() => {
+            reporter = new XunitGenericReporter(reportsDir)
+        })
 
-        const xml2 = await readReport('TEST-file2.xml')
-        expect(xml2.testsuite.$.name).eq('file2')
-        expect(xml2.testsuite.$.tests).eq('1')
-        expect(xml2.testsuite.$.failures).eq('0')
-        expect(xml2.testsuite.testcase).length(1)
-        expect(xml2.testsuite.testcase[0].$.name).eq('file2:93')
+        it('should emit one report file per test file', async () => {
+            reporter.reportTestResult('file1', {
+                source: ['source1'],
+                metadata: metadata('case 1 description'),
+                assertions: [
+                    lineAssertion(0, 1),
+                    lineAssertion(0, 2),
+                ]
+            }, [])
+            reporter.reportTestResult('file2', {
+                source: ['source2'],
+                metadata: metadata(),
+                assertions: [
+                    lineAssertion(0, 3),
+                ]
+            }, [])
+            reporter.reportSuiteResult()
+
+            assertReportFiles(
+                'TEST-file1.xml',
+                'TEST-file2.xml'
+            )
+
+            const xml1 = await readReport('TEST-file1.xml')
+            expect(xml1.testsuite.$.name).eq('case 1 description')
+            expect(xml1.testsuite.$.tests).eq('2')
+            expect(xml1.testsuite.$.failures).eq('0')
+            expect(xml1.testsuite.testcase).length(2)
+            expect(xml1.testsuite.testcase[0].$.name).eq('file1:1')
+            expect(xml1.testsuite.testcase[1].$.name).eq('file1:2')
+
+            const xml2 = await readReport('TEST-file2.xml')
+            expect(xml2.testsuite.$.name).eq('file2')
+            expect(xml2.testsuite.$.tests).eq('1')
+            expect(xml2.testsuite.$.failures).eq('0')
+            expect(xml2.testsuite.testcase).length(1)
+            expect(xml2.testsuite.testcase[0].$.name).eq('file2:3')
+        })
+
+        it('should place reports for test files in nested directories directly into reports directory with mangled names', async () => {
+            reporter.reportTestResult('file1', {
+                source: ['source1'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 1)]
+            }, [])
+            reporter.reportTestResult('dir1/file2', {
+                source: ['source2'],
+                metadata: metadata("case 2 description"),
+                assertions: [lineAssertion(0, 2)]
+            }, [])
+            reporter.reportTestResult('dir1/dir2/file3', {
+                source: ['source3'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 3)]
+            }, [])
+            reporter.reportSuiteResult()
+
+            assertReportFiles(
+                'TEST-file1.xml',
+                'TEST-dir1.file2.xml',
+                'TEST-dir1.dir2.file3.xml',
+            )
+
+            const xml1 = await readReport('TEST-file1.xml')
+            expect(xml1.testsuite.$.name).eq('file1')
+            expect(xml1.testsuite.testcase[0].$.name).eq('file1:1')
+
+            const xml2 = await readReport('TEST-dir1.file2.xml')
+            expect(xml2.testsuite.$.name).eq('case 2 description')
+            expect(xml2.testsuite.testcase[0].$.name).eq('dir1/file2:2')
+
+            const xml3 = await readReport('TEST-dir1.dir2.file3.xml')
+            expect(xml3.testsuite.$.name).eq('dir1/dir2/file3')
+            expect(xml3.testsuite.testcase[0].$.name).eq('dir1/dir2/file3:3')
+        })
+
+        it('should escape reserved characters in failure description', async () => {
+            reporter.reportTestResult('file', {
+                source: [
+                    'xml hell " \' < > &',
+                    // 'assertion',
+                ],
+                metadata: metadata(),
+                assertions: [
+                    lineAssertion(0, 1)
+                ]
+            }, [
+                assertionFailure(0, 1, 0, 1, [], ['m1'], []),
+            ])
+            reporter.reportSuiteResult()
+
+            const xml = await readReport('TEST-file.xml')
+            expect(xml.testsuite.testcase[0].failure[0]._).eq([
+                '1: xml hell " \' < > &', // the escapes were converted back to regular chars by the xml lib when parsing
+                '   ^',
+                'missing required scopes: m1',
+                'actual: ',
+            ].join("\n"))
+        })
+
+        it('should associate assertion failures with source lines', async () => {
+            reporter.reportTestResult('file', {
+                source: [
+                    /*0*/'1  source1',
+                    //   '2  assertion1',
+                    //   '3  assertion2',
+                    /*1*/'4  source2',
+                    //   '5  assertion3',
+                    /*2*/'6  source3',
+                    //   '7  assertion4',
+                    //   '8  assertion5',
+                    /*3*/'9  source4',
+                    //   '10 assertion6',
+                ],
+                metadata: metadata(),
+                assertions: [
+                    lineAssertion(0, 1),
+                    lineAssertion(1, 4),
+                    lineAssertion(2, 6),
+                    lineAssertion(3, 9),
+                ]
+            }, [
+                assertionFailure(0, 1, 0, 1, ['a1', 'a2', 'a3'], ['m1', 'm2'], ['u1']),
+                assertionFailure(2, 6, 0, 3, ['a1', 'a2'], ['m1'], []),
+                assertionFailure(2, 6, 3, 5, ['a1'], [], ['u1']),
+            ])
+            reporter.reportSuiteResult()
+
+            assertReportFiles('TEST-file.xml')
+
+            const xml = await readReport('TEST-file.xml')
+            expect(xml.testsuite.$.tests).eq('4')
+            expect(xml.testsuite.$.failures).eq('3')
+            expect(xml.testsuite.testcase).length(4)
+
+            const [xmlCase1, xmlCase2, xmlCase3, xmlCase4] = xml.testsuite.testcase
+
+            expect(xmlCase1.$.name).eq('file:1')
+            expect(xmlCase1.failure).length(1)
+            const [xmlFailure11] = xmlCase1.failure
+            expect(xmlFailure11.$.message).eq("Assertion failed at 1:1:2")
+            expect(xmlFailure11._).eq([
+                '1: 1  source1',
+                '   ^',
+                'missing required scopes: m1 m2',
+                'prohibited scopes: u1',
+                'actual: a1 a2 a3',
+            ].join("\n"))
+
+            expect(xmlCase2.$.name).eq('file:4')
+            expect(xmlCase2.failure).is.undefined
+
+            expect(xmlCase3.$.name).eq('file:6')
+            expect(xmlCase3.failure).length(2)
+            const [xmlFailure31, xmlFailure32] = xmlCase3.failure
+            expect(xmlFailure31.$.message).eq("Assertion failed at 6:1:4")
+            expect(xmlFailure31._).eq([
+                '6: 6  source3',
+                '   ^^^',
+                'missing required scopes: m1',
+                'actual: a1 a2',
+            ].join("\n"))
+            expect(xmlFailure32.$.message).eq("Assertion failed at 6:4:6")
+            expect(xmlFailure32._).eq([
+                '6: 6  source3',
+                '      ^^',
+                'prohibited scopes: u1',
+                'actual: a1',
+            ].join("\n"))
+
+            expect(xmlCase4.$.name).eq('file:9')
+            expect(xmlCase4.failure).is.undefined
+        })
+
+        it('should create report for test file which fails to parse', async () => {
+            reporter.reportTestResult('file1', {
+                source: ['source1'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 1)]
+            }, [])
+            reporter.reportParseError('file2', new Error(
+                'Expecting the first line in the syntax test file to be in the following format:\n' +
+                '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?\n'))
+            reporter.reportTestResult('file3', {
+                source: ['source3'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 3)]
+            }, [])
+            reporter.reportSuiteResult()
+
+            assertReportFiles(
+                'TEST-file1.xml',
+                'TEST-file2.xml',
+                'TEST-file3.xml',
+            )
+
+            const xml = await readReport('TEST-file2.xml')
+            expect(xml.testsuite.$.tests).eq('1')
+            expect(xml.testsuite.$.failures).eq('0')
+            expect(xml.testsuite.$.errors).eq('1')
+            expect(xml.testsuite.testcase).length(1)
+
+            const xmlCase = xml.testsuite.testcase[0]
+            expect(xmlCase.$.name).eq('Parse test file')
+            expect(xmlCase.failure).is.undefined
+            expect(xmlCase.error).length(1)
+            expect(xmlCase.error[0].$.message).eq("Failed to parse test file")
+            expect(xmlCase.error[0]._).satisfy((m: string) => m.startsWith([
+                'Error: Expecting the first line in the syntax test file to be in the following format:',
+                '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?',
+            ].join("\n")))
+        })
+
+        it('should create report for test file which errors when running grammar test', async () => {
+            reporter.reportTestResult('file1', {
+                source: ['source1'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 1)]
+            }, [])
+            reporter.reportGrammarTestError('file2', {
+                source: ['source1'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 2)]
+            }, new Error('No grammar provided for <foobar>'))
+            reporter.reportTestResult('file3', {
+                source: ['source3'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 3)]
+            }, [])
+            reporter.reportSuiteResult()
+
+            assertReportFiles(
+                'TEST-file1.xml',
+                'TEST-file2.xml',
+                'TEST-file3.xml',
+            )
+
+            const xml = await readReport('TEST-file2.xml')
+            expect(xml.testsuite.$.tests).eq('1')
+            expect(xml.testsuite.$.failures).eq('0')
+            expect(xml.testsuite.$.errors).eq('1')
+            expect(xml.testsuite.testcase).length(1)
+
+            const xmlCase = xml.testsuite.testcase[0]
+            expect(xmlCase.$.name).eq('Run grammar tests')
+            expect(xmlCase.failure).is.undefined
+            expect(xmlCase.error).length(1)
+            expect(xmlCase.error[0].$.message).eq("Error when running grammar tests")
+            expect(xmlCase.error[0]._).satisfy((m: string) => m.startsWith([
+                'Error: No grammar provided for <foobar>',
+            ].join("\n")))
+        })
     })
 
-    it('should place reports for test files in nested directories directly into reports directory with mangled names', async () => {
-        reporter.reportTestResult('file1', {
-            source: ['source1'],
-            metadata: metadata(),
-            assertions: [lineAssertion(10)]
-        }, [])
-        reporter.reportTestResult('dir1/file2', {
-            source: ['source2'],
-            metadata: metadata("case 2 description"),
-            assertions: [lineAssertion(20)]
-        }, [])
-        reporter.reportTestResult('dir1/dir2/file3', {
-            source: ['source3'],
-            metadata: metadata(),
-            assertions: [lineAssertion(30)]
-        }, [])
-        reporter.reportSuiteResult()
+    describe('GitLab-flavored XUnit reporter', () => {
 
-        assertReportFiles(
-            'TEST-file1.xml',
-            'TEST-dir1.file2.xml',
-            'TEST-dir1.dir2.file3.xml',
-        )
+        let reporter: Reporter
 
-        const xml1 = await readReport('TEST-file1.xml')
-        expect(xml1.testsuite.$.name).eq('file1')
-        expect(xml1.testsuite.testcase[0].$.name).eq('file1:10')
+        beforeEach(() => {
+            reporter = new XunitGitlabReporter(reportsDir)
+        })
 
-        const xml2 = await readReport('TEST-dir1.file2.xml')
-        expect(xml2.testsuite.$.name).eq('case 2 description')
-        expect(xml2.testsuite.testcase[0].$.name).eq('dir1/file2:20')
+        it('should always put filename into classname', async () => {
+            reporter.reportTestResult('file1', {
+                source: ['source1'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 1)]
+            }, [])
+            reporter.reportGrammarTestError('file2', {
+                source: ['source1'],
+                metadata: metadata(),
+                assertions: [lineAssertion(0, 2)]
+            }, new Error('No grammar provided for <foobar>'))
+            reporter.reportParseError('file3', new Error(
+                'Expecting the first line in the syntax test file to be in the following format:\n' +
+                '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?\n'))
+            reporter.reportSuiteResult()
 
-        const xml3 = await readReport('TEST-dir1.dir2.file3.xml')
-        expect(xml3.testsuite.$.name).eq('dir1/dir2/file3')
-        expect(xml3.testsuite.testcase[0].$.name).eq('dir1/dir2/file3:30')
-    })
+            const xml1 = await readReport('TEST-file1.xml')
+            expect(xml1.testsuite.testcase[0].$.classname).eq('file1')
 
-    it('should escape reserved characters in failure description', async () => {
-        reporter.reportTestResult('file', {
-            source: [
-                'xml hell " \' < > &',
-                'assertion',
-            ],
-            metadata: metadata(),
-            assertions: [
-                lineAssertion(1)
-            ]
-        }, [
-            assertionFailure(1, 2, 0, 1, [], ['m1'], []),
-        ])
-        reporter.reportSuiteResult()
+            const xml2 = await readReport('TEST-file2.xml')
+            expect(xml2.testsuite.testcase[0].$.classname).eq('file2')
 
-        const xml = await readReport('TEST-file.xml')
-        expect(xml.testsuite.testcase[0].failure[0]._).eq([
-            '  2: xml hell " \' < > &', // the escapes were converted back to regular chars by the xml lib when parsing
-            '     ^',
-            '  missing required scopes: m1',
-            '  actual: ',
-        ].join("\n"))
-    })
+            const xml3 = await readReport('TEST-file3.xml')
+            expect(xml3.testsuite.testcase[0].$.classname).eq('file3')
+        })
 
-    it('should associate assertion failures with source lines', async () => {
-        reporter.reportTestResult('file', {
-            source: [
-                '1  source1',
-                '2  assertion1',
-                '3  assertion2',
-                '4  source2',
-                '5  assertion3',
-                '6  source3',
-                '7  assertion4',
-                '8  assertion5',
-                '9  source4',
-                '10 assertion6',
-            ],
-            metadata: metadata(),
-            assertions: [
-                lineAssertion(1, 2),
-                lineAssertion(1, 3),
-                lineAssertion(4, 5),
-                lineAssertion(6, 7),
-                lineAssertion(6, 8),
-                lineAssertion(9, 10),
-            ]
-        }, [
-            assertionFailure(1, 3, 0, 1, ['a1', 'a2', 'a3'], ['m1', 'm2'], ['u1']),
-            assertionFailure(6, 7, 0, 3, ['a1', 'a2'], ['m1'], []),
-            assertionFailure(6, 8, 3, 5, ['a1'], [], ['u1']),
-        ])
-        reporter.reportSuiteResult()
+        it('should put all failed assertions for one source line into single failure', async () => {
+            reporter.reportTestResult('file', {
+                source: [
+                    /*0*/'1  source1',
+                    //   '2  assertion1',
+                    //   '3  assertion2',
+                    /*1*/'4  source2',
+                    //   '5  assertion3',
+                    /*2*/'6  source3',
+                    //   '7  assertion4',
+                    //   '8  assertion5',
+                    /*3*/'9  source4',
+                    // '10 assertion6',
+                ],
+                metadata: metadata(),
+                assertions: [
+                    lineAssertion(0, 1),
+                    lineAssertion(1, 4),
+                    lineAssertion(2, 6),
+                    lineAssertion(3, 9),
+                ]
+            }, [
+                assertionFailure(0, 1, 0, 1, ['a1', 'a2', 'a3'], ['m1', 'm2'], ['u1']),
+                assertionFailure(2, 6, 0, 3, ['a1', 'a2'], ['m1'], []),
+                assertionFailure(2, 6, 3, 5, ['a1'], [], ['u1']),
+            ])
+            reporter.reportSuiteResult()
 
-        assertReportFiles('TEST-file.xml')
+            assertReportFiles('TEST-file.xml')
 
-        const xml = await readReport('TEST-file.xml')
-        expect(xml.testsuite.$.tests).eq('4')
-        expect(xml.testsuite.$.failures).eq('3')
-        expect(xml.testsuite.testcase).length(4)
+            const xml = await readReport('TEST-file.xml')
+            expect(xml.testsuite.$.tests).eq('4')
+            expect(xml.testsuite.$.failures).eq('2')
+            expect(xml.testsuite.testcase).length(4)
 
-        const [xmlCase1, xmlCase2, xmlCase3, xmlCase4] = xml.testsuite.testcase
+            const [xmlCase1, xmlCase2, xmlCase3, xmlCase4] = xml.testsuite.testcase
 
-        expect(xmlCase1.$.name).eq('file:1')
-        expect(xmlCase1.failure).length(1)
-        const [xmlFailure11] = xmlCase1.failure
-        expect(xmlFailure11.$.message).eq("Assertion failed at 3:1:2")
-        expect(xmlFailure11._).eq([
-            '  3: 1  source1',
-            '     ^',
-            '  missing required scopes: m1 m2',
-            '  prohibited scopes: u1',
-            '  actual: a1 a2 a3',
-        ].join("\n"))
+            expect(xmlCase1.$.name).eq('file:1')
+            expect(xmlCase1.failure).length(1)
+            const [xmlFailure1] = xmlCase1.failure
+            expect(xmlFailure1.$.message).eq("Failed at soure line 1")
+            expect(xmlFailure1._).eq([
+                'at [file:1:1:2]:',
+                '1: 1  source1',
+                '   ^',
+                'missing required scopes: m1 m2',
+                'prohibited scopes: u1',
+                'actual: a1 a2 a3',
+                ''
+            ].join("\n"))
 
-        expect(xmlCase2.$.name).eq('file:4')
-        expect(xmlCase2.failure).is.undefined
+            expect(xmlCase2.$.name).eq('file:4')
+            expect(xmlCase2.failure).is.undefined
 
-        expect(xmlCase3.$.name).eq('file:6')
-        expect(xmlCase3.failure).length(2)
-        const [xmlFailure31, xmlFailure32] = xmlCase3.failure
-        expect(xmlFailure31.$.message).eq("Assertion failed at 7:1:4")
-        expect(xmlFailure31._).eq([
-            '  7: 6  source3',
-            '     ^^^',
-            '  missing required scopes: m1',
-            '  actual: a1 a2',
-        ].join("\n"))
-        expect(xmlFailure32.$.message).eq("Assertion failed at 8:4:6")
-        expect(xmlFailure32._).eq([
-            '  8: 6  source3',
-            '        ^^',
-            '  prohibited scopes: u1',
-            '  actual: a1',
-        ].join("\n"))
+            expect(xmlCase3.$.name).eq('file:6')
+            expect(xmlCase3.failure).length(1)
+            const [xmlFailure3] = xmlCase3.failure
+            expect(xmlFailure3.$.message).eq("Failed at soure line 6")
+            expect(xmlFailure3._).eq([
+                'at [file:6:1:4]:',
+                '6: 6  source3',
+                '   ^^^',
+                'missing required scopes: m1',
+                'actual: a1 a2',
+                '',
+                'at [file:6:4:6]:',
+                '6: 6  source3',
+                '      ^^',
+                'prohibited scopes: u1',
+                'actual: a1',
+                ''
+            ].join("\n"))
 
-        expect(xmlCase4.$.name).eq('file:9')
-        expect(xmlCase4.failure).is.undefined
-    })
-
-    it('should create report for test file which fails to parse', async () => {
-        reporter.reportTestResult('file1', {
-            source: ['source1'],
-            metadata: metadata(),
-            assertions: [lineAssertion(10)]
-        }, [])
-        reporter.reportParseError('file2', new Error(
-            'Expecting the first line in the syntax test file to be in the following format:\n' +
-            '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?\n'))
-        reporter.reportTestResult('file3', {
-            source: ['source3'],
-            metadata: metadata(),
-            assertions: [lineAssertion(30)]
-        }, [])
-        reporter.reportSuiteResult()
-
-        assertReportFiles(
-            'TEST-file1.xml',
-            'TEST-file2.xml',
-            'TEST-file3.xml',
-        )
-
-        const xml = await readReport('TEST-file2.xml')
-        expect(xml.testsuite.$.tests).eq('1')
-        expect(xml.testsuite.$.failures).eq('0')
-        expect(xml.testsuite.$.errors).eq('1')
-        expect(xml.testsuite.testcase).length(1)
-
-        const xmlCase = xml.testsuite.testcase[0]
-        expect(xmlCase.$.name).eq('Parse test file')
-        expect(xmlCase.failure).is.undefined
-        expect(xmlCase.error).length(1)
-        expect(xmlCase.error[0].$.message).eq("Failed to parse test file")
-        expect(xmlCase.error[0]._).satisfy((m: string) => m.startsWith([
-            'Error: Expecting the first line in the syntax test file to be in the following format:',
-            '<comment character(s)> SYNTAX TEST "<language identifier>"  ("description")?',
-        ].join("\n")))
-    })
-
-    it('should create report for test file which errors when running grammar test', async () => {
-        reporter.reportTestResult('file1', {
-            source: ['source1'],
-            metadata: metadata(),
-            assertions: [lineAssertion(10)]
-        }, [])
-        reporter.reportGrammarTestError('file2', {
-            source: ['source1'],
-            metadata: metadata(),
-            assertions: [lineAssertion(10)]
-        }, new Error('No grammar provided for <foobar>'))
-        reporter.reportTestResult('file3', {
-            source: ['source3'],
-            metadata: metadata(),
-            assertions: [lineAssertion(30)]
-        }, [])
-        reporter.reportSuiteResult()
-
-        assertReportFiles(
-            'TEST-file1.xml',
-            'TEST-file2.xml',
-            'TEST-file3.xml',
-        )
-
-        const xml = await readReport('TEST-file2.xml')
-        expect(xml.testsuite.$.tests).eq('1')
-        expect(xml.testsuite.$.failures).eq('0')
-        expect(xml.testsuite.$.errors).eq('1')
-        expect(xml.testsuite.testcase).length(1)
-
-        const xmlCase = xml.testsuite.testcase[0]
-        expect(xmlCase.$.name).eq('Run grammar tests')
-        expect(xmlCase.failure).is.undefined
-        expect(xmlCase.error).length(1)
-        expect(xmlCase.error[0].$.message).eq("Error when running grammar tests")
-        expect(xmlCase.error[0]._).satisfy((m: string) => m.startsWith([
-            'Error: No grammar provided for <foobar>',
-        ].join("\n")))
+            expect(xmlCase4.$.name).eq('file:9')
+            expect(xmlCase4.failure).is.undefined
+        })
     })
 
     const assertReportFiles: (...expected: string[]) => void = (...expected: string[]) => {
@@ -297,14 +414,12 @@ function metadata(description?: string): TestCaseMetadata {
     }
 }
 
-function lineAssertion(sourceLineNumber: number, testCaseLineNumber?: number): LineAssertion {
+function lineAssertion(sourceLineNumber: number, testCaseLineNumber: number): LineAssertion {
     return {
-        sourceLineNumber: sourceLineNumber - 1,
-        testCaseLineNumber: testCaseLineNumber
-            ? testCaseLineNumber - 1
-            : sourceLineNumber,
+        sourceLineNumber,
+        testCaseLineNumber: testCaseLineNumber - 1,
         scopeAssertions: [{
-            from: 1, to: 2, scopes: ['scope1'], exclude: []
+            from: -1, to: -2, scopes: ['scope1'], exclude: []
         }]
     }
 }
@@ -316,7 +431,7 @@ function assertionFailure(
 ): TestFailure {
     return {
         actual, missing, unexpected,
-        srcLine: sourceLineNumber - 1,
+        srcLine: sourceLineNumber,
         line: testCaseLineNumber - 1,
         start, end
     }

--- a/test/unit/unit/reporter.test.ts
+++ b/test/unit/unit/reporter.test.ts
@@ -1,0 +1,249 @@
+'use strict'
+import { expect } from 'chai'
+import * as fs from 'fs'
+import * as p from 'path'
+import { parseStringPromise } from 'xml2js'
+
+import { XunitReporter } from '../../../src/unit/reporter'
+import { GrammarTestCase, LineAssertion, TestCaseMetadata, TestFailure } from '../../../src/unit/model'
+
+describe('XUnit reporter', () => {
+
+    function metadata(description?: string): TestCaseMetadata {
+        return {
+            scope: 'main.scope',
+            commentToken: '//',
+            description: description || "",
+            allowMiddleLineAssertions: true
+        }
+    }
+
+    function lineAssertion(sourceLineNumber: number, testCaseLineNumber?: number): LineAssertion {
+        return {
+            sourceLineNumber: sourceLineNumber - 1,
+            testCaseLineNumber: testCaseLineNumber
+                ? testCaseLineNumber - 1
+                : sourceLineNumber,
+            scopeAssertions: [{
+                from: 1, to: 2, scopes: ['scope1'], exclude: []
+            }]
+        }
+    }
+
+    function assertionFailure(
+        sourceLineNumber: number, testCaseLineNumber: number,
+        start: number, end: number,
+        actual: string[], missing: string[], unexpected: string[],
+    ): TestFailure {
+        return {
+            actual, missing, unexpected,
+            srcLine: sourceLineNumber - 1,
+            line: testCaseLineNumber - 1,
+            start, end
+        }
+    }
+
+    let reportsDir: string
+    let reporter: XunitReporter
+
+    beforeEach(() => {
+        reportsDir = fs.mkdtempSync("/tmp/reports_")
+        reporter = new XunitReporter(reportsDir)
+    })
+
+    afterEach(() => {
+        fs.rmdirSync(reportsDir, { recursive: true })
+    })
+
+    it('should emit one report file per test file', async () => {
+        reporter.reportTestResult('file1', {
+            source: ['source1'],
+            metadata: metadata('case 1 description'),
+            assertions: [
+                lineAssertion(71),
+                lineAssertion(82),
+            ]
+        }, [])
+        reporter.reportTestResult('file2', {
+            source: ['source2'],
+            metadata: metadata(),
+            assertions: [
+                lineAssertion(93),
+            ]
+        }, [])
+        reporter.reportSuiteResult()
+
+        const reportFiles = fs.readdirSync(reportsDir)
+        expect(reportFiles)
+            .members([
+                'TEST-file1.xml',
+                'TEST-file2.xml'
+            ])
+            .length(2)
+
+        const xml1 = await readReport('TEST-file1.xml')
+        expect(xml1.testsuite.$.name).eq('case 1 description')
+        expect(xml1.testsuite.$.tests).eq('2')
+        expect(xml1.testsuite.$.failures).eq('0')
+        expect(xml1.testsuite.testcase).length(2)
+        expect(xml1.testsuite.testcase[0].$.name).eq('file1:71')
+        expect(xml1.testsuite.testcase[1].$.name).eq('file1:82')
+
+        const xml2 = await readReport('TEST-file2.xml')
+        expect(xml2.testsuite.$.name).eq('file2')
+        expect(xml2.testsuite.$.tests).eq('1')
+        expect(xml2.testsuite.$.failures).eq('0')
+        expect(xml2.testsuite.testcase).length(1)
+        expect(xml2.testsuite.testcase[0].$.name).eq('file2:93')
+    })
+
+    it('should place reports for test files in nested directories directly into reports directory with mangled names', async () => {
+        reporter.reportTestResult('file1', {
+            source: ['source1'],
+            metadata: metadata(),
+            assertions: [lineAssertion(10)]
+        }, [])
+        reporter.reportTestResult('dir1/file2', {
+            source: ['source2'],
+            metadata: metadata("case 2 description"),
+            assertions: [lineAssertion(20)]
+        }, [])
+        reporter.reportTestResult('dir1/dir2/file3', {
+            source: ['source3'],
+            metadata: metadata(),
+            assertions: [lineAssertion(30)]
+        }, [])
+        reporter.reportSuiteResult()
+
+        const reportFiles = fs.readdirSync(reportsDir)
+        expect(reportFiles)
+            .members([
+                'TEST-file1.xml',
+                'TEST-dir1.file2.xml',
+                'TEST-dir1.dir2.file3.xml',
+            ])
+            .length(3)
+
+        const xml1 = await readReport('TEST-file1.xml')
+        expect(xml1.testsuite.$.name).eq('file1')
+        expect(xml1.testsuite.testcase[0].$.name).eq('file1:10')
+
+        const xml2 = await readReport('TEST-dir1.file2.xml')
+        expect(xml2.testsuite.$.name).eq('case 2 description')
+        expect(xml2.testsuite.testcase[0].$.name).eq('dir1/file2:20')
+
+        const xml3 = await readReport('TEST-dir1.dir2.file3.xml')
+        expect(xml3.testsuite.$.name).eq('dir1/dir2/file3')
+        expect(xml3.testsuite.testcase[0].$.name).eq('dir1/dir2/file3:30')
+    })
+
+    it('should escape reserved characters in failure description', async () => {
+        reporter.reportTestResult('file', {
+            source: [
+                'xml hell " \' < > &',
+                'assertion',
+            ],
+            metadata: metadata(),
+            assertions: [
+                lineAssertion(1)
+            ]
+        }, [
+            assertionFailure(1, 2, 0, 1, [], ['m1'], []),
+        ])
+        reporter.reportSuiteResult()
+
+        const xml = await readReport('TEST-file.xml')
+        expect(xml.testsuite.testcase[0].failure[0]._).eq([
+            '  2: xml hell " \' < > &', // the escapes were converted back to regular chars by the xml lib when parsing
+            '     ^',
+            '  missing required scopes: m1',
+            '  actual: ',
+        ].join("\n"))
+    })
+
+    it('should associate failures with assertions', async () => {
+        reporter.reportTestResult('file', {
+            source: [
+                '1  source1',
+                '2  assertion1',
+                '3  assertion2',
+                '4  source2',
+                '5  assertion3',
+                '6  source3',
+                '7  assertion4',
+                '8  assertion5',
+                '9  source4',
+                '10 assertion6',
+            ],
+            metadata: metadata(),
+            assertions: [
+                lineAssertion(1, 2),
+                lineAssertion(1, 3),
+                lineAssertion(4, 5),
+                lineAssertion(6, 7),
+                lineAssertion(6, 8),
+                lineAssertion(9, 10),
+            ]
+        }, [
+            assertionFailure(1, 3, 0, 1, ['a1', 'a2', 'a3'], ['m1', 'm2'], ['u1']),
+            assertionFailure(6, 7, 0, 3, ['a1', 'a2'], ['m1'], []),
+            assertionFailure(6, 8, 3, 5, ['a1'], [], ['u1']),
+        ])
+        reporter.reportSuiteResult()
+
+        const reportFiles = fs.readdirSync(reportsDir)
+        expect(reportFiles)
+            .members([
+                'TEST-file.xml',
+            ])
+            .length(1)
+
+        const xml = await readReport('TEST-file.xml')
+        expect(xml.testsuite.$.tests).eq('4')
+        expect(xml.testsuite.$.failures).eq('3')
+        expect(xml.testsuite.testcase).length(4)
+
+        const [xmlCase1, xmlCase2, xmlCase3, xmlCase4] = xml.testsuite.testcase
+
+        expect(xmlCase1.$.name).eq('file:1')
+        expect(xmlCase1.failure).length(1)
+        const [xmlFailure11] = xmlCase1.failure
+        expect(xmlFailure11.$.message).eq("Assertion failed at 3:1:2")
+        expect(xmlFailure11._).eq([
+            '  3: 1  source1',
+            '     ^',
+            '  missing required scopes: m1 m2',
+            '  prohibited scopes: u1',
+            '  actual: a1 a2 a3',
+        ].join("\n"))
+
+        expect(xmlCase2.$.name).eq('file:4')
+        expect(xmlCase2.failure).is.undefined
+
+        expect(xmlCase3.$.name).eq('file:6')
+        expect(xmlCase3.failure).length(2)
+        const [xmlFailure31, xmlFailure32] = xmlCase3.failure
+        expect(xmlFailure31.$.message).eq("Assertion failed at 7:1:4")
+        expect(xmlFailure31._).eq([
+            '  7: 6  source3',
+            '     ^^^',
+            '  missing required scopes: m1',
+            '  actual: a1 a2',
+        ].join("\n"))
+        expect(xmlFailure32.$.message).eq("Assertion failed at 8:4:6")
+        expect(xmlFailure32._).eq([
+            '  8: 6  source3',
+            '        ^^',
+            '  prohibited scopes: u1',
+            '  actual: a1',
+        ].join("\n"))
+
+        expect(xmlCase4.$.name).eq('file:9')
+        expect(xmlCase4.failure).is.undefined
+    })
+
+    const readReport: (filename: string) => any = async (filename: string) => {
+        return await parseStringPromise(fs.readFileSync(p.resolve(reportsDir, filename)))
+    }
+})
+


### PR DESCRIPTION
Closes #42

I tried to do as few changes as possible to the existing stuff. 
Mostly I just moved all the reporting-related code into new `unit/reporter.ts` and made a few things in the existing functions parameterizable to make them usable also when rendering the xml report.

No new prod dependencies are added - I render the xml by simple string templating. `xml2js` is added just as dev dependency to make writing tests for the reporter easier and to make sure the emitted files are actually valid xml.

I also took the liberty to add `.vscode/launch.json` as its useful when debugging the tests and you already have some `.vscode` files comitted in the repo.

Don't hesitate to let me know if you want anything changed